### PR TITLE
fcm make: build: fix diag: bad ns-dep, dup targets

### DIFF
--- a/lib/FCM/Util/Event.pm
+++ b/lib/FCM/Util/Event.pm
@@ -196,7 +196,7 @@ our %S = (
     e_sys_build_target_bad       => '%s: don\'t know how to build specified'
                                     . ' target',
     e_sys_build_target_cyclic    => '%s: target depends on itself',
-    e_sys_build_target_dep       => '%s: missing dependency (type=%s)',
+    e_sys_build_target_dep       => '%s: bad or missing dependency (type=%s)',
     e_sys_build_target_dup       => '%s: same target from [%s]',
     e_sys_build_target_stack     => '    required by: %s',
     e_sys_cache_load             => '%s: cannot retrieve cache',
@@ -462,7 +462,14 @@ sub _format_e_sys_build_target_dep {
     while (my ($key, $hash_ref) = each(%{$e->get_ctx()})) {
         my ($head, @stack) = reverse(@{$hash_ref->{'keys'}});
         for (@{$hash_ref->{'values'}}) { # [$dep_key, $dep_type]
-            push(@messages, sprintf($S{e_sys_build_target_dep}, @{$_}));
+            my ($dep_name, $dep_type, $dep_remark) = @{$_};
+            if ($dep_remark) {
+                $dep_type = $dep_remark . '.' . $dep_type;
+            }
+            push(
+                @messages,
+                sprintf($S{e_sys_build_target_dep}, $dep_name, $dep_type),
+            );
         }
         push(@messages, map {sprintf($S{e_sys_build_target_stack}, $_)} @stack);
     }

--- a/t/fcm-make/07-build-ns-dep/fcm-make.cfg
+++ b/t/fcm-make/07-build-ns-dep/fcm-make.cfg
@@ -1,0 +1,5 @@
+steps=build
+build.source=$HERE/src
+build.target{task}=link
+$FCM_TEST_NS_DEP_O{?}=foo
+build.prop{ns-dep.o}=$FCM_TEST_NS_DEP_O

--- a/t/fcm-make/07-build-ns-dep/src/lib/earth.f90
+++ b/t/fcm-make/07-build-ns-dep/src/lib/earth.f90
@@ -1,0 +1,4 @@
+subroutine world(w)
+character(*), intent(out) :: w
+w = 'Earth'
+end subroutine world

--- a/t/fcm-make/07-build-ns-dep/src/lib/greet.f90
+++ b/t/fcm-make/07-build-ns-dep/src/lib/greet.f90
@@ -1,0 +1,4 @@
+subroutine greet(hello, world)
+character(*), intent(in) :: hello, world
+write(*, '(A,1X,A)') trim(hello), trim(world)
+end subroutine greet

--- a/t/fcm-make/07-build-ns-dep/src/main/hello.f90
+++ b/t/fcm-make/07-build-ns-dep/src/main/hello.f90
@@ -1,0 +1,13 @@
+program hello
+character(5) :: w
+interface
+subroutine greet(hello, world)
+character(*), intent(in) :: hello, world
+end subroutine greet
+subroutine world(w)
+character(*), intent(out) :: w
+end subroutine world
+end interface
+call world(w)
+call greet('Hello', w)
+end program hello

--- a/t/fcm-make/08-build-dup-dep.t
+++ b/t/fcm-make/08-build-dup-dep.t
@@ -1,0 +1,49 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2006-2013 Met Office.
+#
+# This file is part of FCM, tools for managing and building source code.
+#
+# FCM is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FCM is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FCM. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Tests for "fcm make", "build.prop{ns-dep.o}".
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+tests 4
+set -e
+cp -r $TEST_SOURCE_DIR/$TEST_KEY_BASE/* .
+set +e
+#-------------------------------------------------------------------------------
+TEST_KEY="$TEST_KEY_BASE-bad"
+run_fail "$TEST_KEY" fcm make
+cat .fcm-make/log
+tail -2 .fcm-make/log >"$TEST_KEY.log"
+file_cmp "$TEST_KEY.log" "$TEST_KEY.log" <<'__LOG__'
+[FAIL] world.o: same target from [lib/earth.f90, lib/moon.f90]
+[FAIL]     required by: hello.exe
+__LOG__
+#-------------------------------------------------------------------------------
+TEST_KEY="$TEST_KEY_BASE"
+rm src/lib/moon.f90
+run_pass "$TEST_KEY" fcm make
+sed '/^\[info\] target /!d' .fcm-make/log >"$TEST_KEY.log"
+file_cmp "$TEST_KEY.log" "$TEST_KEY.log" <<'__LOG__'
+[info] target hello.exe
+[info] target  - greet.o
+[info] target  - world.o
+[info] target  - hello.o
+__LOG__
+#-------------------------------------------------------------------------------
+exit 0

--- a/t/fcm-make/08-build-dup-dep/fcm-make.cfg
+++ b/t/fcm-make/08-build-dup-dep/fcm-make.cfg
@@ -1,0 +1,4 @@
+steps=build
+build.source=$HERE/src
+build.target{task}=link
+build.prop{ns-dep.o}=lib

--- a/t/fcm-make/08-build-dup-dep/src/lib/earth.f90
+++ b/t/fcm-make/08-build-dup-dep/src/lib/earth.f90
@@ -1,0 +1,4 @@
+subroutine world(w)
+character(*), intent(out) :: w
+w = 'Earth'
+end subroutine world

--- a/t/fcm-make/08-build-dup-dep/src/lib/greet.f90
+++ b/t/fcm-make/08-build-dup-dep/src/lib/greet.f90
@@ -1,0 +1,4 @@
+subroutine greet(hello, world)
+character(*), intent(in) :: hello, world
+write(*, '(A,1X,A)') trim(hello), trim(world)
+end subroutine greet

--- a/t/fcm-make/08-build-dup-dep/src/lib/moon.f90
+++ b/t/fcm-make/08-build-dup-dep/src/lib/moon.f90
@@ -1,0 +1,4 @@
+subroutine world(w)
+character(*), intent(out) :: w
+w = 'Moon'
+end subroutine world

--- a/t/fcm-make/08-build-dup-dep/src/main/hello.f90
+++ b/t/fcm-make/08-build-dup-dep/src/main/hello.f90
@@ -1,0 +1,13 @@
+program hello
+character(5) :: w
+interface
+subroutine greet(hello, world)
+character(*), intent(in) :: hello, world
+end subroutine greet
+subroutine world(w)
+character(*), intent(out) :: w
+end subroutine world
+end interface
+call world(w)
+call greet('Hello', w)
+end program hello


### PR DESCRIPTION
Improve diagnostics for a bad `ns-dep`.
Correct diagnostics for duplicated target, which was reported as missing
dependency.
