### PR TITLE
FCM::Admin::System: hotcopy then verify

### DIFF
--- a/lib/FCM/Admin/System.pm
+++ b/lib/FCM/Admin/System.pm
@@ -280,7 +280,7 @@ sub backup_svn_repository {
                     sub {
                         my ($base_name, $path) = @_;
                         my $rev = basename($base_name, '.gz');
-                        if (!$rev || $rev > $youngest) {
+                        if ($rev > $youngest) {
                             return;
                         }
                         push(@rev_dump_paths, $path);
@@ -761,7 +761,7 @@ sub recover_svn_repository {
             sub {
                 my ($base_name, $path) = @_;
                 my $rev = basename($base_name, '.gz');
-                if (!$rev || $rev <= $youngest) {
+                if ($rev <= $youngest) {
                     return;
                 }
                 push(@rev_dump_paths, $path);


### PR DESCRIPTION
Verify the hotcopy instead of the original to ensure the integrity of
the backup.
Also fix `REV.gz` file name sort error.
