### PR TITLE
fcm mkpatch: use bash in generated scripts

### DIFF
--- a/lib/FCM1/Cm.pm
+++ b/lib/FCM1/Cm.pm
@@ -1271,9 +1271,8 @@ sub cm_mkpatch {
     open FILE, '>', $out or die $out, ': cannot open (', $!, ')';
 
     # Script header
-    my $shell = FCM1::Config->instance()->setting(qw/TOOL SHELL/);
     print FILE <<EOF;
-#!$shell
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
 # NAME
 #   apply-patch
@@ -1355,7 +1354,7 @@ EOF
 
     # Script header
     print FILE <<EOF;
-#!/bin/bash
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
 # NAME
 #   fcm-import-patch


### PR DESCRIPTION
It looks like the generated controlling script is already using `bash`, so there is really no reason why the inner script should use a different shell.

Fix #64.
