### PR TITLE
Installation doc: add remark on RHEL Perl

### DIFF
--- a/doc/installation/index.html
+++ b/doc/installation/index.html
@@ -60,6 +60,14 @@
       <p><dfn>used by:</dfn> <code>fcm</code>.</p>
 
       <p><dfn>versions known to work:</dfn> 5.10.1.</p>
+
+      <p><dfn>remark:</dfn> We assume that all <em>core</em> Perl modules (as
+      documented by <a href="http://perldoc.perl.org/">perldoc.perl.org</a>) of
+      the <em>known to work versions</em> are installed on your system. (N.B. On
+      platforms based on RHEL, you may need the <em>perl-core</em> RPM instead
+      of just <em>perl</em>, see <a href=
+      "http://www.nntp.perl.org/group/perl.perl5.porters/2009/08/msg149891.html">this
+      discussion</a>.)</p>
     </dd>
 
     <dt>Perl module <a href=


### PR DESCRIPTION
On RHEL based platform, the Perl RPM does not contain all core Perl
modules of a Perl release. Users should request their site admin to
install Perl-Core.
