### PR TITLE
fcm make: extract: SSH location: ignore dot files

### DIFF
--- a/lib/FCM/Util/Locator/SSH.pm
+++ b/lib/FCM/Util/Locator/SSH.pm
@@ -106,9 +106,13 @@ sub _find {
         die($value_hash_ref);
     }
     my $found;
+    LINE:
     for my $line (grep {$_} split("\n", $value_hash_ref->{o})) {
         $found ||= 1;
         my ($md5sum, $name) = split(q{ }, $line, 2);
+        if ($name =~ qr{/\.[^/]+}msx) { # Ignore Unix hidden files
+            next LINE;
+        }
         my $ns = substr($name, length($path) + 1);
         $callback->(
             $auth . ':' . $name,

--- a/t/fcm-make/06-extract-ssh.t
+++ b/t/fcm-make/06-extract-ssh.t
@@ -41,10 +41,11 @@ if [[ -z $T_HOST ]]; then
 fi
 #-------------------------------------------------------------------------------
 # Create a source tree on the remote host
-mkdir -p hello/{greet,hello,hi}
+mkdir -p hello/{greet,hello,hi,.secret}
 for NAME in mercury venus earth mars; do
     echo "Greet $NAME" >hello/greet/greet_${NAME}.txt
     echo "Hello $NAME" >hello/hello/hello_${NAME}.txt
+    echo "[Alien-speak] $NAME" >hello/.secret/hello_${NAME}.txt
     echo "Hi $NAME" >hello/hi/hi_${NAME}.txt
 done
 T_HOST_WORK_DIR=$(ssh -oBatchMode=yes $T_HOST mktemp -d)


### PR DESCRIPTION
This change ensures that `fcm make` extract system Ignores Unix hidden files in SSH locations.
