### PR TITLE
Fix test battery: fcm make version string in log

### DIFF
--- a/t/fcm-make/10-log.t
+++ b/t/fcm-make/10-log.t
@@ -31,6 +31,7 @@ if [[ -d $FCM_HOME/.git ]]; then
 else
     VERSION=$(sed '/FCM\.VERSION/!d; s/^.*="\(.*\)";$/\1/' \
         $FCM_HOME/doc/etc/fcm-version.js)
+    VERSION="FCM $VERSION"
 fi
 file_grep "$TEST_KEY.log.version" "\\[info\\] $VERSION" .fcm-make/log
 file_grep "$TEST_KEY.log.mode" '\[info\] mode=new' .fcm-make/log

--- a/t/lib/bash/test_header
+++ b/t/lib/bash/test_header
@@ -149,6 +149,7 @@ function file_grep() {
 }
 
 FCM_HOME=${FCM_HOME:-$(cd $(dirname $BASH_SOURCE)/../../.. && pwd)}
+export FCM_HOME
 PATH=$FCM_HOME/bin:$PATH
 SVN_VERSION_IS_16=false
 SVN_VERSION=$(svn --version)


### PR DESCRIPTION
Fix test battery fails if `FCM_HOME` not defined, or if it is not a Git
clone.
