### PR TITLE
fcm make: remove prev ctx as each step completes

### DIFF
--- a/lib/FCM/System/Make.pm
+++ b/lib/FCM/System/Make.pm
@@ -220,6 +220,12 @@ sub _main {
                     die($e);
                 }
                 $ctx->set_status($m_ctx->ST_OK);
+                my $prev_m_ctx = $m_ctx->get_prev_ctx();
+                if (    defined($prev_m_ctx)
+                    &&  exists($prev_m_ctx->get_ctx_of()->{$step})
+                ) {
+                    delete($prev_m_ctx->get_ctx_of()->{$step});
+                }
             }
         },
     )};


### PR DESCRIPTION
This should reduce the memory footprint that was causing Perl to exit
with SIGSEGV.
