### PR TITLE
fcm make: steps: don't inherit if already set

### DIFF
--- a/lib/FCM/System/Make.pm
+++ b/lib/FCM/System/Make.pm
@@ -196,6 +196,14 @@ sub _main {
             for my $step (@INIT_STEPS) {
                 $T->(sub {$ACTION_OF{$step}->(\%attrib, $m_ctx, @args)}, $step);
             }
+            my $prev_m_ctx = $m_ctx->get_prev_ctx();
+            if (defined($prev_m_ctx)) {
+                for my $step (keys(%{$prev_m_ctx->get_ctx_of()})) {
+                    if (!grep {$_ eq $step} @{$m_ctx->get_steps()}) {
+                        delete($prev_m_ctx->get_ctx_of()->{$step});
+                    }
+                }
+            }
             for my $step (@{$m_ctx->get_steps()}) {
                 my $ctx = $m_ctx->get_ctx_of($step);
                 if (!defined($ctx)) {
@@ -220,7 +228,6 @@ sub _main {
                     die($e);
                 }
                 $ctx->set_status($m_ctx->ST_OK);
-                my $prev_m_ctx = $m_ctx->get_prev_ctx();
                 if (    defined($prev_m_ctx)
                     &&  exists($prev_m_ctx->get_ctx_of()->{$step})
                 ) {

--- a/lib/FCM/System/Make/Share/Config.pm
+++ b/lib/FCM/System/Make/Share/Config.pm
@@ -206,9 +206,9 @@ sub _parse_use {
                 }
             }
         }
-        $m_ctx->set_steps([@{$i_m_ctx->get_steps()}]);
-        # FIXME: should only inherit context in steps?
-        # FIXME: handle the situation where the inherited make has been moved.
+        if (!@{$m_ctx->get_steps()}) {
+            $m_ctx->set_steps([@{$i_m_ctx->get_steps()}]);
+        }
     }
 }
 
@@ -238,8 +238,8 @@ sub _unparse {
                         : ()
                     ;
                 }
-            (   [\&_unparse_steps   , 'steps'],
-                [\&_unparse_use     , 'use'  ],
+            (   [\&_unparse_use     , 'use'  ],
+                [\&_unparse_steps   , 'steps'],
                 [sub {$m_ctx->get_dest()}, 'dest' ],
             ),
         ),

--- a/t/fcm-make/21-inherit-steps.t
+++ b/t/fcm-make/21-inherit-steps.t
@@ -1,0 +1,68 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2006-14 Met Office.
+#
+# This file is part of FCM, tools for managing and building source code.
+#
+# FCM is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FCM is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FCM. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Tests "fcm make", ensure that steps can be declared before or after use=
+# declaration.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+tests 3
+set -e
+mkdir -p i0 i1 i2 i3
+cp -r $TEST_SOURCE_DIR/$TEST_KEY_BASE/* i0
+fcm make -q -C i0
+set +e
+#-------------------------------------------------------------------------------
+TEST_KEY="$TEST_KEY_BASE-i1"
+cat >i1/fcm-make.cfg <<'__FCM_MAKE_CFG__'
+use=$HERE/../i0
+__FCM_MAKE_CFG__
+fcm make -q -C i1
+find i1/*/bin -type f | sort >"$TEST_KEY.ls"
+file_cmp "$TEST_KEY.ls" "$TEST_KEY.ls" <<'__LIST__'
+i1/build1/bin/hello.exe
+i1/build2/bin/salute.exe
+i1/build3/bin/greet.exe
+__LIST__
+#-------------------------------------------------------------------------------
+TEST_KEY="$TEST_KEY_BASE-i2"
+cat >i2/fcm-make.cfg <<'__FCM_MAKE_CFG__'
+step.class[build1 build2]=build
+steps=build1 build2
+use=$HERE/../i0
+__FCM_MAKE_CFG__
+fcm make -q -C i2
+find i2/*/bin -type f | sort >"$TEST_KEY.ls"
+file_cmp "$TEST_KEY.ls" "$TEST_KEY.ls" <<'__LIST__'
+i2/build1/bin/hello.exe
+i2/build2/bin/salute.exe
+__LIST__
+#-------------------------------------------------------------------------------
+TEST_KEY="$TEST_KEY_BASE-i3"
+cat >i3/fcm-make.cfg <<'__FCM_MAKE_CFG__'
+use=$HERE/../i0
+steps=build3
+__FCM_MAKE_CFG__
+fcm make -q -C i3
+find i3/*/bin -type f | sort >"$TEST_KEY.ls"
+file_cmp "$TEST_KEY.ls" "$TEST_KEY.ls" <<'__LIST__'
+i3/build3/bin/greet.exe
+__LIST__
+#-------------------------------------------------------------------------------
+exit 0

--- a/t/fcm-make/21-inherit-steps/fcm-make.cfg
+++ b/t/fcm-make/21-inherit-steps/fcm-make.cfg
@@ -1,0 +1,8 @@
+step.class[build1 build2 build3]=build
+steps=build1 build2 build3
+build1.source=$HERE/src1
+build1.target{task}=link
+build2.source=$HERE/src2
+build2.target{task}=link
+build3.source=$HERE/src3
+build3.target{task}=link

--- a/t/fcm-make/21-inherit-steps/src1/hello.f90
+++ b/t/fcm-make/21-inherit-steps/src1/hello.f90
@@ -1,0 +1,3 @@
+program hello
+write(*, '(a)') 'Hello!'
+end program hello

--- a/t/fcm-make/21-inherit-steps/src2/salute.f90
+++ b/t/fcm-make/21-inherit-steps/src2/salute.f90
@@ -1,0 +1,3 @@
+program salute
+write(*, '(a)') 'Salute!'
+end program salute

--- a/t/fcm-make/21-inherit-steps/src3/greet.f90
+++ b/t/fcm-make/21-inherit-steps/src3/greet.f90
@@ -1,0 +1,3 @@
+program greet
+write(*, '(a)') 'Greeting!'
+end program greet


### PR DESCRIPTION
Hence, allow `steps=` to be declared before `use=`.

In addition:
- incr mode: on load of prev ctx, remove prev ctx of irrelevant steps.
- config unparse: `use=` before `steps=`.
