### PR TITLE
FCM_CONF_PATH: override site/user conf paths

### DIFF
--- a/doc/user_guide/command_ref.html
+++ b/doc/user_guide/command_ref.html
@@ -75,6 +75,18 @@
   command.</p>
 
   <dl>
+    <dt id="env.FCM_CONF_PATH">FCM_CONF_PATH='/path/to/conf1
+    /path/to/conf2'</dt>
+
+    <dd>This variable is mainly used to test FCM. If specified, override the
+    paths for site and user configuration files.  The value should be a space
+    delimited list of paths where FCM site and user configuration files can be
+    found. The value can also be set to a null string to allow FCM to run with
+    no site or user configuration.  If not defined, the default to look for site
+    and user configuration files from <code>$FCM_HOME/etc/fcm/</code> and
+    <code>~/.metomi/fcm/</code> (where <var>$FCM_HOME/bin/fcm</var> is where the
+    <code>fcm</code> command is invoked.</dd>
+
     <dt id="env.FCM_DEBUG">FCM_DEBUG=true</dt>
 
     <dd>If specified, raises the verbosity to the <dfn>debug</dfn> level. This

--- a/lib/FCM/Admin/Config.pm
+++ b/lib/FCM/Admin/Config.pm
@@ -65,7 +65,7 @@ sub instance {
         $INSTANCE = bless({%DEFAULT_R, %DEFAULT_RW}, $class);
         # Load $FCM_HOME/etc/fcm/admin.cfg and $HOME/.metomi/fcm/admin.cfg
         my $UTIL = FCM::Util->new();
-        my @paths = map {catfile($_, 'admin.cfg')} ($UTIL->cfg_paths());
+        my @paths = map {catfile($_, 'admin.cfg')} ($UTIL->conf_paths());
         for my $path (grep {-f $_ && -r _} @paths) {
             my $config_reader
                 = $UTIL->config_reader(FCM::Context::Locator->new($path));

--- a/lib/FCM/System/CM/SVN.pm
+++ b/lib/FCM/System/CM/SVN.pm
@@ -489,7 +489,7 @@ sub _load_layout_config {
         for my $path (
             grep {-f $_ && -r _}
                 map {catfile($_, $attrib_ref->{layout_cfg_base})}
-                    $attrib_ref->{util}->cfg_paths()
+                    $attrib_ref->{util}->conf_paths()
         ) {
             my $config_reader_ref = $attrib_ref->{util}->config_reader(
                 FCM::Context::Locator->new($path),

--- a/lib/FCM/System/Make.pm
+++ b/lib/FCM/System/Make.pm
@@ -96,7 +96,7 @@ sub _init {
     for my $path (
         grep {-f $_ && -r _}
             map {catfile($_, $attrib_ref->{cfg_base})}
-                $attrib_ref->{util}->cfg_paths()
+                $attrib_ref->{util}->conf_paths()
     ) {
         my $config_reader_ref = $attrib_ref->{util}->config_reader(
             FCM::Context::Locator->new($path),

--- a/t/fcm-keyword-print/00-simple.t
+++ b/t/fcm-keyword-print/00-simple.t
@@ -1,0 +1,67 @@
+#!/bin/bash
+# ------------------------------------------------------------------------------
+# (C) British Crown Copyright 2006-14 Met Office.
+#
+# This file is part of FCM, tools for managing and building source code.
+#
+# FCM is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FCM is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FCM. If not, see <http://www.gnu.org/licenses/>.
+# ------------------------------------------------------------------------------
+# Basic tests for "fcm keyword-print".
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+svnadmin create plants
+URL="file://$PWD/plants"
+svn mkdir --parents -q -m 'test' $URL/{daisy,ivy,holly}/trunk
+mkdir -p conf
+cat >conf/keyword.cfg <<__CFG__
+location{primary}[daisy]=$URL/daisy
+location{primary}[ivy]=$URL/ivy
+location{primary}[holly]=$URL/holly
+__CFG__
+export FCM_CONF_PATH=$PWD/conf
+#-------------------------------------------------------------------------------
+tests 21
+#-------------------------------------------------------------------------------
+TEST_KEY="$TEST_KEY_BASE" # no argument
+run_pass "$TEST_KEY" fcm kp
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
+location{primary}[daisy] = $URL/daisy
+location{primary}[holly] = $URL/holly
+location{primary}[ivy] = $URL/ivy
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+#-------------------------------------------------------------------------------
+for NS in daisy ivy holly; do
+    TEST_KEY="$TEST_KEY_BASE-$NS" # normal mode
+    run_pass "$TEST_KEY" fcm kp fcm:$NS
+    file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
+location{primary}[$NS] = $URL/$NS
+__OUT__
+    file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+
+    TEST_KEY="$TEST_KEY_BASE-v-$NS" # verbose mode
+    run_pass "$TEST_KEY" fcm kp -v fcm:$NS
+    file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
+location{primary}[$NS] = $URL/$NS
+location[${NS}-br] = $URL/$NS/branches
+location[${NS}-tg] = $URL/$NS/tags
+location[${NS}-tr] = $URL/$NS/trunk
+location[${NS}_br] = $URL/$NS/branches
+location[${NS}_tg] = $URL/$NS/tags
+location[${NS}_tr] = $URL/$NS/trunk
+__OUT__
+    file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+done
+#-------------------------------------------------------------------------------
+exit

--- a/t/fcm-keyword-print/test_header
+++ b/t/fcm-keyword-print/test_header
@@ -1,0 +1,1 @@
+../lib/bash/test_header


### PR DESCRIPTION
If `FCM_CONF_PATH` is defined in the environment, use its value as paths
to site and user configuration files.

Close #104. See also metomi/rose#1160.
