### PR TITLE
fcm make: inherited build: fix non-failure

### DIFF
--- a/lib/FCM/System/Make/Build.pm
+++ b/lib/FCM/System/Make/Build.pm
@@ -959,6 +959,7 @@ sub _targets_props_assign {
             else {
                 $target->set_path_of_prev($p_target->get_path_of_prev());
                 $target->set_prop_of_prev_of($p_target->get_prop_of_prev_of());
+                $target->set_status($target->ST_OOD);
             }
             if (exists($NO_INHERIT_CATEGORY_IN{$target->get_category()})) {
                 $target->set_path_of_prev($target->get_path());

--- a/t/fcm-make/22-build-2-bad-mod-over-inherit.t
+++ b/t/fcm-make/22-build-2-bad-mod-over-inherit.t
@@ -1,0 +1,59 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2006-14 Met Office.
+#
+# This file is part of FCM, tools for managing and building source code.
+#
+# FCM is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FCM is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FCM. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Tests "fcm make", inherit build correctness. metomi/fcm#110
+# * 2 source files with bad syntax override.
+# * Build fails on first source file.
+# * Fix first source file.
+# * Build should fail on second source file.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+tests 7
+set -e
+mkdir -p i0 i1
+cp -r $TEST_SOURCE_DIR/$TEST_KEY_BASE/{fcm-make.cfg,src} i0
+fcm make -q -C i0
+set +e
+#-------------------------------------------------------------------------------
+cp -r $TEST_SOURCE_DIR/$TEST_KEY_BASE/src-i i1/src
+cat >i1/fcm-make.cfg <<'__CFG__'
+use=$HERE/../i0
+build.source=$HERE/src
+__CFG__
+#-------------------------------------------------------------------------------
+TEST_KEY="$TEST_KEY_BASE-i1-1"
+run_fail "$TEST_KEY" fcm make -q -C i1
+file_grep "$TEST_KEY.err" '\[FAIL\].*i1/src/m1.f90' "$TEST_KEY.err"
+#-------------------------------------------------------------------------------
+TEST_KEY="$TEST_KEY_BASE-i1-2"
+sed 's/^writ/write/' $TEST_SOURCE_DIR/$TEST_KEY_BASE/src-i/m1.f90 >i1/src/m1.f90
+run_fail "$TEST_KEY" fcm make -q -C i1
+file_grep "$TEST_KEY.err" '\[FAIL\].*i1/src/m2.f90' "$TEST_KEY.err"
+#-------------------------------------------------------------------------------
+TEST_KEY="$TEST_KEY_BASE-i1-3"
+sed 's/^writ/write/' $TEST_SOURCE_DIR/$TEST_KEY_BASE/src-i/m2.f90 >i1/src/m2.f90
+run_pass "$TEST_KEY" fcm make -q -C i1 --new
+run_pass "$TEST_KEY.exe" $PWD/i1/build/bin/p1.exe
+file_cmp "$TEST_KEY.exe.out" "$TEST_KEY.exe.out" <<'__OUT__'
+Greet from m1-s1!
+Greet from m2-s2!
+__OUT__
+#-------------------------------------------------------------------------------
+exit

--- a/t/fcm-make/22-build-2-bad-mod-over-inherit/fcm-make.cfg
+++ b/t/fcm-make/22-build-2-bad-mod-over-inherit/fcm-make.cfg
@@ -1,0 +1,3 @@
+steps=build
+build.source=$HERE/src
+build.target=p1.exe

--- a/t/fcm-make/22-build-2-bad-mod-over-inherit/src-i/m1.f90
+++ b/t/fcm-make/22-build-2-bad-mod-over-inherit/src-i/m1.f90
@@ -1,0 +1,6 @@
+module m1
+contains
+subroutine s1()
+writ(*, '(a)') 'Greet from m1-s1!'
+end subroutine s1
+end module m1

--- a/t/fcm-make/22-build-2-bad-mod-over-inherit/src-i/m2.f90
+++ b/t/fcm-make/22-build-2-bad-mod-over-inherit/src-i/m2.f90
@@ -1,0 +1,6 @@
+module m2
+contains
+subroutine s2()
+writ(*, '(a)') 'Greet from m2-s2!'
+end subroutine s2
+end module m2

--- a/t/fcm-make/22-build-2-bad-mod-over-inherit/src/m1.f90
+++ b/t/fcm-make/22-build-2-bad-mod-over-inherit/src/m1.f90
@@ -1,0 +1,6 @@
+module m1
+contains
+subroutine s1()
+write(*, '(a)') 'Hello from m1:s1!'
+end subroutine s1
+end module m1

--- a/t/fcm-make/22-build-2-bad-mod-over-inherit/src/m2.f90
+++ b/t/fcm-make/22-build-2-bad-mod-over-inherit/src/m2.f90
@@ -1,0 +1,6 @@
+module m2
+contains
+subroutine s2()
+write(*, '(a)') 'Hello from m2:s2!'
+end subroutine s2
+end module m2

--- a/t/fcm-make/22-build-2-bad-mod-over-inherit/src/p1.f90
+++ b/t/fcm-make/22-build-2-bad-mod-over-inherit/src/p1.f90
@@ -1,0 +1,6 @@
+program p1
+use m1, only: s1
+use m2, only: s2
+call s1()
+call s2()
+end program p1


### PR DESCRIPTION
This change fixes #110.

Recipe to repeat bug:
- Inherit a build.
- Override with 2 independent Fortran source files containing modules.
- Both files cause build failure. (E.g. due to syntax error.)
- Run `fcm make` once, 1st source file fails.
- Fix 1st source file.
- Run `fcm make` again. Should fail, but doesn't.
