### PR TITLE
fcm make: build: recognise intrinsic OMP modules

### DIFF
--- a/lib/FCM/System/Make/Build/FileType/Fortran.pm
+++ b/lib/FCM/System/Make/Build/FileType/Fortran.pm
@@ -36,7 +36,13 @@ our $FILE_EXT = '.F .F90 .F95 .FOR .FTN .f .f90 .f95 .for .ftn .inc';
 
 # List of Fortran intrinsic modules
 our @INTRINSIC_MODULES = qw{
-    iso_c_binding iso_fortran_env ieee_exceptions ieee_arithmetic ieee_features
+    ieee_arithmetic
+    ieee_exceptions
+    ieee_features
+    iso_c_binding
+    iso_fortran_env
+    omp_lib
+    omp_lib_kinds
 };
 
 # Prefix for dependency name that is only applicable under OMP

--- a/t/fcm-make/23-build-omp/src/p1.f90
+++ b/t/fcm-make/23-build-omp/src/p1.f90
@@ -1,5 +1,6 @@
 program p1
 
+!$ use omp_lib
 !$ use m1, only: s1
 !$ use m2, only: s2
 


### PR DESCRIPTION
`fcm make` build system now recognises `omp_lib` and `omp_lib_kinds` as intrinsic modules.
