### PR TITLE
fcm make: ssh extract: find printf instead of find exec stat

### DIFF
--- a/lib/FCM/Util/Locator/SSH.pm
+++ b/lib/FCM/Util/Locator/SSH.pm
@@ -99,7 +99,7 @@ sub _find {
     my $value_hash_ref = $attrib_ref->{util}->shell_simple([
         _shell_cmd_list($attrib_ref, 'ssh'),
         $auth,
-        "find $path -type f -not -path '*/.*' -exec stat -c'%Y %n' {} ';'",
+        "find $path -type f -not -path \"*/.*\" -printf \"%T@ %p\\\\n\"",
     ]);
     if ($value_hash_ref->{rc}) {
         die($value_hash_ref);


### PR DESCRIPTION
This change results in a speed up of two orders of magnitude on some of the systems I have tested on. Down from ~40 seconds to ~0.4 for a full scan of a source tree , when the meta data is likely in cache, and perhaps an order of magnitude speed up when the meta data is not likely to be in cache.

I've ran the test battery and all is fine.
