### PR TITLE
Remove most -r -w -x tests to avoid ACL problem

### DIFF
--- a/bin/fcm_internal
+++ b/bin/fcm_internal
@@ -280,7 +280,7 @@ sub load {
         for my $dir (@objpath) {
           my $full = catfile ($dir, $file);
 
-          if (-r $full) {
+          if (-f $full) {
             $file = $full;
             last;
           }

--- a/lib/FCM/Admin/Config.pm
+++ b/lib/FCM/Admin/Config.pm
@@ -65,17 +65,18 @@ sub instance {
         $INSTANCE = bless({%DEFAULT_R, %DEFAULT_RW}, $class);
         # Load $FCM_HOME/etc/fcm/admin.cfg and $HOME/.metomi/fcm/admin.cfg
         my $UTIL = FCM::Util->new();
-        my @paths = map {catfile($_, 'admin.cfg')} ($UTIL->conf_paths());
-        for my $path (grep {-f $_ && -r _} @paths) {
-            my $config_reader
-                = $UTIL->config_reader(FCM::Context::Locator->new($path));
-            while (defined(my $entry = $config_reader->())) {
-                my $label = $entry->get_label();
-                if (exists($INSTANCE->{$label})) {
-                    $INSTANCE->{$label} = $entry->get_value();
+        $UTIL->cfg_init(
+            'admin.cfg',
+            sub {
+                my $config_reader = shift();
+                while (defined(my $entry = $config_reader->())) {
+                    my $label = $entry->get_label();
+                    if (exists($INSTANCE->{$label})) {
+                        $INSTANCE->{$label} = $entry->get_value();
+                    }
                 }
-            }
-        }
+            },
+        );
     }
     return $INSTANCE;
 }

--- a/lib/FCM/Admin/System.pm
+++ b/lib/FCM/Admin/System.pm
@@ -613,7 +613,7 @@ sub manage_users_in_svn_passwd {
             my $USERS_SECTION = q{users};
             my $svn_passwd_ini;
             my $is_changed;
-            if (-f $svn_passwd_file && -r $svn_passwd_file) {
+            if (-f $svn_passwd_file) {
                 $svn_passwd_ini
                     = Config::IniFiles->new(q{-file} => $svn_passwd_file);
             }
@@ -665,7 +665,7 @@ sub manage_users_in_trac_passwd {
         sub {
             my %old_names;
             my %new_names = %{$user_ref};
-            if (-f $trac_passwd_file && -r $trac_passwd_file) {
+            if (-f $trac_passwd_file) {
                 read_file(
                     $trac_passwd_file,
                     sub {

--- a/lib/FCM/System/CM.pm
+++ b/lib/FCM/System/CM.pm
@@ -565,7 +565,7 @@ sub _get_username {
                 $rhs =~ s{[.]}{\\.}gmsx;
                 $rhs =~ s{[*]}{.*}gmsx;
                 $rhs =~ s{[?]}{.?}gmsx;
-                if ($host =~ qr{\A$rhs\z}msx) {
+                if ($host && $host =~ qr{\A$rhs\z}msx) {
                     $group = $lhs;
                     last LINE;
                 }

--- a/lib/FCM/System/Make/Share/Dest.pm
+++ b/lib/FCM/System/Make/Share/Dest.pm
@@ -100,7 +100,7 @@ sub _dest_done {
     }
     my $dest = _path($attrib_ref, $m_ctx, 'sys-ctx-uncompressed');
     my $dest_parent = dirname($dest);
-    if (-d $dest_parent && -w $dest_parent) {
+    if (-d $dest_parent) {
         eval {
             my $handle = IO::File->new_tmpfile();
             nstore_fd($m_ctx, $handle) || die($!);
@@ -176,8 +176,7 @@ sub _dest_init {
     # Loads context of previous make, if possible
     my $prev_m_ctx = eval {
         my $path = _path($attrib_ref, $m_ctx, 'sys-ctx');
-        -f $path && -r _
-            ? _ctx_load($attrib_ref, $path, blessed($m_ctx)) : undef;
+        -f $path ? _ctx_load($attrib_ref, $path, blessed($m_ctx)) : undef;
     };
     if (my $e = $@) {
         if (!$E->caught($e) || $e->get_code() ne $E->CACHE_LOAD) {

--- a/lib/FCM/Util/Locator/FS.pm
+++ b/lib/FCM/Util/Locator/FS.pm
@@ -95,9 +95,6 @@ sub _find {
 sub _reader {
     my ($attrib_ref, $value) = @_;
     $value = _parse($attrib_ref, $value);
-    if (!-f $value || !-r _) {
-        die("$!\n");
-    }
     open(my $handle, '<', $value) || die("$!\n");
     return $handle;
 }

--- a/lib/FCM/Util/Shell.pm
+++ b/lib/FCM/Util/Shell.pm
@@ -212,7 +212,9 @@ sub _which {
     if (file_name_is_absolute($name)) {
         return $name;
     }
+    use filetest 'access';
     first {-f $_ && -x _} map {catfile($_, $name)} path();
+    no filetest 'access';
 }
 
 # ------------------------------------------------------------------------------

--- a/lib/FCM1/Build.pm
+++ b/lib/FCM1/Build.pm
@@ -762,7 +762,7 @@ sub invoke_scan_dependency {
 
   # Check whether make file is out of date
   # ----------------------------------------------------------------------------
-  my $out_of_date = not -r $self->dest->bldmakefile;
+  my $out_of_date = ! -f $self->dest->bldmakefile;
 
   if ($rc and not $out_of_date) {
     for (qw/CACHE CACHE_DEP/) {
@@ -1217,7 +1217,7 @@ sub parse_cfg_source {
     my $value = $line->value;
     $value = File::Spec->rel2abs (&expand_tilde ($value), $self->dest->srcdir);
 
-    if (not -r $value) {
+    if (! -e $value) {
       $line->error ($value . ': source does not exist or is not readable.');
       next;
     }
@@ -1253,7 +1253,7 @@ sub parse_cfg_source {
       next if $base =~ /^\./;
 
       my $file = File::Spec->catfile ($src{$key}, $base);
-      next unless -f $file and -r $file;
+      next if ! -f $file;
 
       my $name = join ('__', ($key, $base));
       $src{$name} = $file unless exists $src{$name};

--- a/lib/FCM1/BuildTask.pm
+++ b/lib/FCM1/BuildTask.pm
@@ -230,7 +230,7 @@ sub action {
     } elsif ($self->actiontype eq 'COPY') {
       # Action is COPY: copy file to destination if necessary
       # ------------------------------------------------------------------------
-      my $copy_required = ($dep_uptodate and $self->output and -r $self->output)
+      my $copy_required = ($dep_uptodate and $self->output and -f $self->output)
                           ? compare ($self->output, $self->srcfile->src)
                           : 1;
 
@@ -285,7 +285,7 @@ sub action {
       my $update_required = 1;
       my $oldfile = find_file_in_path ($base, \@path);
 
-      if ($oldfile and -r $oldfile) {
+      if ($oldfile and -f $oldfile) {
         # Read old file
         open FILE, '<', $oldfile;
         my @oldlines = readline 'FILE';

--- a/lib/FCM1/Config.pm
+++ b/lib/FCM1/Config.pm
@@ -642,12 +642,12 @@ for my $name (qw/central_config user_config user_id verbose/) {
     if (not defined $self->{$name}) {
       if ($name eq 'central_config') {
         # Central configuration file
-        if (-r catfile (dirname ($FindBin::Bin), 'etc', 'fcm.cfg')) {
+        if (-f catfile (dirname ($FindBin::Bin), 'etc', 'fcm.cfg')) {
           $self->{$name} = catfile (
             dirname ($FindBin::Bin), 'etc', 'fcm.cfg'
           );
 
-        } elsif (-r catfile ($FindBin::Bin, 'fcm.cfg')) {
+        } elsif (-f catfile ($FindBin::Bin, 'fcm.cfg')) {
           $self->{$name} = catfile ($FindBin::Bin, 'fcm.cfg');
         }
 
@@ -656,7 +656,7 @@ for my $name (qw/central_config user_config user_id verbose/) {
         my $home = (getpwuid ($<))[7];
         $home = $ENV{HOME} if not defined $home;
         $self->{$name} = catfile ($home, '.fcm')
-          if defined ($home) and -r catfile ($home, '.fcm');
+          if defined ($home) and -f catfile ($home, '.fcm');
 
       } elsif ($name eq 'user_id') {
         # User ID of current process
@@ -834,7 +834,7 @@ sub _read_config_file {
   my $self        = shift;
   my $config_file = $_[0];
 
-  if (!$config_file || !-f $config_file || !-r $config_file) {
+  if (!$config_file || !-f $config_file) {
     return;
   }
 

--- a/lib/FCM1/ConfigSystem.pm
+++ b/lib/FCM1/ConfigSystem.pm
@@ -233,7 +233,7 @@ sub compare_setting {
               ? File::Spec->catfile ($self->dest->cachedir, $cachebase)
               : $self->dest->cache;
   my @in_caches = ();
-  if (-r $cache) {
+  if (-f $cache) {
     push @in_caches, $cache;
 
   } else {
@@ -241,13 +241,13 @@ sub compare_setting {
       my $use_cache = $cachebase
                       ? File::Spec->catfile ($use->dest->cachedir, $cachebase)
                       : $use->dest->cache;
-      push @in_caches, $use_cache if -r $use_cache;
+      push @in_caches, $use_cache if -f $use_cache;
     }
   }
 
   my $old_lines = undef;
   for my $in_cache (@in_caches) {
-    next unless -r $in_cache;
+    next unless -f $in_cache;
     my $cfg = FCM1::CfgFile->new (SRC => $in_cache);
 
     if ($cfg->read_cfg) {

--- a/lib/FCM1/Dest.pm
+++ b/lib/FCM1/Dest.pm
@@ -188,7 +188,7 @@ sub DESTROY {
   my $self = shift;
 
   # Remove the lockfile if it is set
-  unlink $self->lockfile if $self->lockfile and -w $self->lockfile;
+  unlink $self->lockfile if $self->lockfile and -f $self->lockfile;
 
   return;
 }
@@ -516,8 +516,8 @@ sub create {
     }
 
     # Check whether directory exists and is writable
-    unless (-d $dir and -w $dir) {
-      w_report 'ERROR: ', $dir, ': cannot write to destination.';
+    if (!-d $dir) {
+      w_report 'ERROR: ', $dir, ': cannot create destination.';
       $rc = 0;
     }
   }
@@ -638,7 +638,6 @@ sub get_source_files {
     &find (sub {
       return if /^\./;                    # ignore system/hidden file
       return if -d $File::Find::name;     # ignore directory
-      return if not -r $File::Find::name; # ignore unreadable files
 
       my $name = join (
         '__', @{ $self->get_pkgname_of_path ($File::Find::name) },

--- a/lib/FCM1/ReposBranch.pm
+++ b/lib/FCM1/ReposBranch.pm
@@ -343,7 +343,7 @@ sub expand_all {
       my $wanted = sub {
         my $base_name = $_;
         my $path = $File::Find::name;
-        if (-f $path && -r $path && !-l $path) {
+        if (-f $path && !-l $path) {
           my $dir_path      = dirname($path);
           my $rel_dir_path  = File::Spec->abs2rel($dir_path, $root_locator);
           if ($rel_dir_path eq q{.}) {

--- a/lib/FCM1/SrcDirLayer.pm
+++ b/lib/FCM1/SrcDirLayer.pm
@@ -212,7 +212,7 @@ sub update_cache {
   my $dirname = dirname $self->cachedir;
   mkpath($dirname);
 
-  if (!-w $dirname) {
+  if (!-d $dirname) {
     _err('CACHE_WRITE', [$dirname]);
   }
   


### PR DESCRIPTION
Most of these tests are unnecessary.
Use `filetest` pragma in the only one case where these tests make sense.
Where possible, load site-user configurations with a single function that accepts a callback.

Fix #127.
