### PR TITLE
fcm commit: don't commit message file

### DIFF
--- a/lib/FCM/System/CM/CommitMessage.pm
+++ b/lib/FCM/System/CM/CommitMessage.pm
@@ -49,13 +49,14 @@ our $SUBVERSION_CONFIG_FILE = catfile((getpwuid($<))[7], qw{.subversion/config})
 
 __PACKAGE__->class({gui => '$', util => '&'},
     {action_of => {
-        'ctx'     => sub {$CTX->new()},
-        'edit'    => \&_edit,
-        'load'    => \&_load,
-        'notify'  => \&_notify,
-        'path'    => \&_path,
-        'save'    => \&_save,
-        'temp'    => \&_temp,
+        'ctx'       => sub {$CTX->new()},
+        'edit'      => \&_edit,
+        'load'      => \&_load,
+        'notify'    => \&_notify,
+        'path'      => \&_path,
+        'path_base' => sub {$COMMIT_MESSAGE_BASE},
+        'save'      => \&_save,
+        'temp'      => \&_temp,
     }},
 );
 
@@ -288,6 +289,10 @@ Raise a CM_COMMIT_MESSAGE event with the $commit_message_ctx.
 
 Return the path to the commit message file in $dir or the current working
 directory if $dir is not specified.
+
+=item $commit_message_util->path($dir)
+
+Return the base name of the commit message file.
 
 =item $commit_message_util->save($commit_message_ctx, $path)
 

--- a/lib/FCM1/Cm.pm
+++ b/lib/FCM1/Cm.pm
@@ -106,6 +106,7 @@ our %CLI_MESSAGE_FOR_ERROR = (
     NOT_EXIST           => "%s: does not exist.\n",
     PARENT_NOT_EXIST    => "%s: parent %s no longer exists.\n",
     RMTREE              => "%s: cannot remove.\n",
+    ST_CI_MESG_FILE     => "Attempt to add commit message file:\n%s",
     ST_CONFLICT         => "File(s) in conflicts:\n%s",
     ST_MISSING          => "File(s) missing:\n%s",
     ST_OOD              => "File(s) out of date:\n%s",
@@ -471,6 +472,16 @@ sub cm_commit {
   # Abort if there is no change in the working copy
   if (!@status) {
     return _cm_abort(FCM1::Cm::Abort->NULL);
+  }
+
+  # Abort if attempt to add commit message file
+  my $ci_mesg_file_base = $COMMIT_MESSAGE_UTIL->path_base();
+  my @bad_status = grep {$_ =~ qr{^A.*?\s$ci_mesg_file_base\n}m} @status;
+  if (@bad_status) {
+    for my $bad_status (@bad_status) {
+      $CLI_MESSAGE->('ST_CI_MESG_FILE', $bad_status);
+    }
+    return _cm_abort(FCM1::Cm::Abort->FAIL);
   }
 
   # Get associated URL of current working copy

--- a/t/fcm-commit/03-message-file.t
+++ b/t/fcm-commit/03-message-file.t
@@ -1,0 +1,58 @@
+#!/bin/bash
+# ------------------------------------------------------------------------------
+# (C) British Crown Copyright 2006-14 Met Office.
+#
+# This file is part of FCM, tools for managing and building source code.
+#
+# FCM is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FCM is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FCM. If not, see <http://www.gnu.org/licenses/>.
+# ------------------------------------------------------------------------------
+# Tests for "fcm commit", attempt to add commit message file.
+#-------------------------------------------------------------------------------
+. $(dirname $0)/test_header
+#-------------------------------------------------------------------------------
+tests 6
+#-------------------------------------------------------------------------------
+svnadmin create foo
+svn co -q file://$PWD/foo 'test-work'
+touch 'test-work/#commit_message#'
+svn add 'test-work/#commit_message#'
+export SVN_EDITOR='cat'
+#-------------------------------------------------------------------------------
+# Tests fcm commit, bad commit file 1
+TEST_KEY="$TEST_KEY_BASE-1"
+run_fail "$TEST_KEY" fcm commit --svn-non-interactive 'test-work'
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
+$PWD/test-work: working directory changed to top of working copy.
+__OUT__
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
+[ERROR] Attempt to add commit message file:
+A       #commit_message#
+[FAIL] FCM1::Cm::Abort: abort
+
+__ERR__
+#-------------------------------------------------------------------------------
+# Tests fcm commit, bad commit file 2
+TEST_KEY="$TEST_KEY_BASE-2"
+cd 'test-work'
+run_fail "$TEST_KEY" fcm commit --svn-non-interactive
+cd ..
+file_cmp "$TEST_KEY.out" "$TEST_KEY.out" </dev/null
+file_cmp "$TEST_KEY.err" "$TEST_KEY.err" <<'__ERR__'
+[ERROR] Attempt to add commit message file:
+A       #commit_message#
+[FAIL] FCM1::Cm::Abort: abort
+
+__ERR__
+#-------------------------------------------------------------------------------
+exit


### PR DESCRIPTION
`fcm commit` will now abort if status line contains:

```
A       #commit_message#
```

Close #134. (Sort of.)
