### PR TITLE
Use old logic to add user to svnserve passwd file

### DIFF
--- a/lib/FCM/Admin/System.pm
+++ b/lib/FCM/Admin/System.pm
@@ -747,10 +747,8 @@ sub manage_users_in_svn_passwd {
                     $RUNNER->run(
                         "adding $user to $svn_passwd_file",
                         sub {
-                            my $password = qx{uuidgen};
-                            chomp($password);
                             $svn_passwd_ini->newval(
-                                $USERS_SECTION, $user->get_name(), $password,
+                                $USERS_SECTION, $user->get_name(), q{},
                             ),
                         },
                     );


### PR DESCRIPTION
This allows us to avoid any complications.
