### PR TITLE
Add the option to use meld as the diff and merge tool.

### DIFF
--- a/bin/fcm_graphic_diff
+++ b/bin/fcm_graphic_diff
@@ -35,6 +35,7 @@ my %S = (
 my %LABELS_HANDLER_FOR = (
     'tkdiff' => sub {map {('-L', $_)} @_},
     'xxdiff' => sub {('--title1', $_[0], '--title2', $_[1])},
+    'meld'   => sub {map {('-L', $_)} @_},
 );
 
 if (!caller()) {
@@ -115,10 +116,11 @@ If OLD_LABEL and NEW_LABEL are set, they are printed in the format:
     ++++ NEW_LABEL
 
 The command makes use of the labels when the diff command is either
-L<xxdiff|xxdiff> or L<tkdiff|tkdiff>:
+L<xxdiff|xxdiff>, L<tkdiff|tkdiff>, or L<meld|meld>:
 
     xxdiff --title1 OLD_LABEL --title2 NEW_LABEL OLD NEW
     tkdiff -L OLD_LABEL -L NEW_LABEL OLD NEW
+    meld   -L OLD_LABEL -L NEW_LABEL OLD NEW
 
 The command returns 0 if the files are the same or 1 if the files differ. All
 other return codes should be regarded as fatal errors.

--- a/bin/fcm_graphic_merge
+++ b/bin/fcm_graphic_merge
@@ -23,6 +23,7 @@ use warnings;
 
 my %IMPL = ('fcm-dummy-diff' => \&_fcm_dummy_diff,
             'xxdiff' => \&_xxdiff,
+            'meld'   => \&_meld,
             'kdiff3' => \&_kdiff3);
 
 my %UNRESOLVED = (
@@ -93,6 +94,23 @@ sub _kdiff3 {
     return 0;
 }
 
+sub _meld {
+    my ($base, $mine, $older, $yours) = @_;
+    # Not using --auto-merge option as it alters the middle pane before user
+    # can review changes.
+    my @command = (qw{meld -a -o}, $base, $mine, $older, $yours);
+    my @out_lines = qx{@command};
+    my $rc = $?;
+    # meld doesn't produce any output, so we just assume a non-zero
+    # exit code means unresolved merges
+    if ($rc) {
+        print($UNRESOLVED{'merged'});
+        return 1;
+    }
+    printf("You merged all the changes.\n");
+    return 0;
+}
+
 __END__
 
 =head1 NAME
@@ -104,6 +122,9 @@ fcm_graphic_merge
     fcm_graphic_merge BASE MINE OLDER YOURS
 
 =head1 DESCRIPTION
+
+Invokes L<xxdiff|xxdiff> (or the command specified in the FCM_GRAPHIC_MERGE
+environment variable) to compare the CURRENT, ANCESTOR and NEW files, where possible.
 
 Wrap L<xxdiff|xxdiff>. Invoke L<xxdiff|xxdiff> as:
 


### PR DESCRIPTION
Not an ideal tool for similar reasons to k3diff not working well within FCM.
Meld looked very promising in description, but not something I'll be switching to immediately.
