### PR TITLE
add-trac-env: don't add TICKET_EDIT_COMMENT

### DIFF
--- a/lib/FCM/Admin/System.pm
+++ b/lib/FCM/Admin/System.pm
@@ -193,14 +193,6 @@ sub add_trac_environment {
         "adding TICKET_EDIT_DESCRIPTION permission to authenticated",
         qw{permission add}, 'authenticated', qw{TICKET_EDIT_DESCRIPTION},
     );
-    eval {$TRAC_ADMIN->(
-        "adding TICKET_EDIT_COMMENT permission to authenticated",
-        qw{permission add}, 'authenticated', qw{TICKET_EDIT_COMMENT},
-    )};
-    if ($@) {
-        # Expected to fail for Trac < 0.12
-        $@ = undef;
-    }
     $RUN->(
         "adding names and emails of users",
         sub {manage_users_in_trac_db_of($project, {get_users()})},


### PR DESCRIPTION
This is not necessary because 1) admin users can do this already and 2)
authenticated users can edit their own comments any way.
