### PR TITLE
fcm bls: improve svn info failure error

### DIFF
--- a/lib/FCM/System/CM.pm
+++ b/lib/FCM/System/CM.pm
@@ -300,8 +300,10 @@ sub _cm_branch_create {
 sub _cm_branch_list {
     my ($attrib_ref, $option_ref, @args) = @_;
     _parse_args($attrib_ref, $option_ref, \@args);
+    my $used_default_arg;
     if (!@args) {
         @args = cwd() . '@HEAD';
+        $used_default_arg = 1;
     }
     my %common_patterns_at;
     if ($option_ref->{'only'} && @{$option_ref->{'only'}}) {
@@ -317,6 +319,10 @@ sub _cm_branch_list {
         my %patterns_at = %{dclone(\%common_patterns_at)};
         my %info = eval {%{$attrib_ref->{svn}->get_info($arg)->[0]}};
         if ($@) {
+            if ($used_default_arg) {
+                # Can't complain about a bad arg if we put it there.
+                return $E->throw($E->SHELL, $@->{ctx}, $@->{ctx}->{e});
+            }
             return $E->throw($E->CM_ARG, $arg);
         }
         my $url = $info{'url'} . '@' . $info{'revision'};


### PR DESCRIPTION
At the moment, running `fcm bls` in a working copy with non-cached server
authentication results in a failure with this error message:

```
[FAIL] /my/working/copy@HEAD: bad argument
```

This is the default argument inserted by fcm, so the user is being told off unnecessarily.
This changes the error message to reflect the actual 'svn info' failure when default arguments are used:

```
FAIL] svn info --xml /my/working/copy@HEAD # rc=1
[FAIL] svn: E215004: Authentication failed and interactive prompting is disabled; see the --force-interactive option
[FAIL] svn: E215004: Unable to connect to a repository at URL 'https://my/repository'
[FAIL] svn: E215004: No more credentials or we tried too many times.
[FAIL] Authentication failed
```

@matthewrmshin, please review.
