### PR TITLE
fcm cm: return more svn error info

### DIFF
--- a/lib/FCM/System/CM/SVN.pm
+++ b/lib/FCM/System/CM/SVN.pm
@@ -623,7 +623,8 @@ sub _stdout {
     if ($value_of{rc}) {
         return $E->throw(
             $E->SHELL,
-            {command_list => \@command, %value_of}
+            {command_list => \@command, %value_of},
+            $value_of{e}
         );
     }
     wantarray() ? split("\n", $value_of{o}) : $value_of{o};


### PR DESCRIPTION
When an internally run subversion command fails, this will return more error information.

This is good for problems such as authentication with --non-interactive, but not so good
for other problems such as spelling branch names wrong, etc.

This addresses the majority of individual `fcm` commands' cryptic authentication failure
behaviour.

@matthewrmshin, please consider and review.
