### PR TITLE
fcm branch-delete: fail if bad arg specified

### DIFF
--- a/lib/FCM1/Cm.pm
+++ b/lib/FCM1/Cm.pm
@@ -257,11 +257,11 @@ sub _branch_url {
     my $url
         = $arg && is_url($arg) ? FCM1::CmUrl->new(URL => $arg)
         : $arg && is_wc($arg)  ? FCM1::CmUrl->new(URL => get_url_of_wc($arg))
-        : is_wc()              ? FCM1::CmUrl->new(URL => get_url_of_wc())
+        : !$arg && is_wc()     ? FCM1::CmUrl->new(URL => get_url_of_wc())
         :                        undef
         ;
     if (!$url) {
-        return _cm_err(FCM1::Cm::Exception->INVALID_TARGET, '.');
+        return _cm_err(FCM1::Cm::Exception->INVALID_TARGET, $arg ? $arg : q{.});
     }
     $url;
 }

--- a/t/fcm-branch-delete/00-simple.t
+++ b/t/fcm-branch-delete/00-simple.t
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with FCM. If not, see <http://www.gnu.org/licenses/>.
 # ------------------------------------------------------------------------------
-# Basic tests for "fcm branch-create".
+# Basic tests for "fcm branch-delete".
 #-------------------------------------------------------------------------------
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------

--- a/t/fcm-branch-delete/01-bad-arg.t
+++ b/t/fcm-branch-delete/01-bad-arg.t
@@ -1,0 +1,40 @@
+#!/bin/bash
+# ------------------------------------------------------------------------------
+# (C) British Crown Copyright 2006-14 Met Office.
+#
+# This file is part of FCM, tools for managing and building source code.
+#
+# FCM is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FCM is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FCM. If not, see <http://www.gnu.org/licenses/>.
+# ------------------------------------------------------------------------------
+# Test "fcm branch-delete" with bad argument and in a working copy.
+#-------------------------------------------------------------------------------
+. "$(dirname "$0")/test_header"
+tests 3
+#-------------------------------------------------------------------------------
+# Tests fcm branch-delete with bad argument, and in a working copy
+TEST_KEY="${TEST_KEY_BASE}"
+setup
+init_repos
+init_branch 'branch_test' "${REPOS_URL}"
+init_branch_wc 'my_branch_test' "${REPOS_URL}"
+cd "${TEST_DIR}/wc"
+run_fail "${TEST_KEY}" fcm branch-delete --non-interactive 'dark-matter'
+file_cmp "${TEST_DIR}/${TEST_KEY}.out" "${TEST_KEY}.out" </dev/null
+file_cmp "${TEST_DIR}/${TEST_KEY}.err" "${TEST_KEY}.err" <<'__ERR__'
+[FAIL] dark-matter: not a valid working copy or URL.
+
+__ERR__
+teardown
+#-------------------------------------------------------------------------------
+exit


### PR DESCRIPTION
Previously, if a bad argument is specified while in a working copy, it
will continue to use the working copy URL.