### PR TITLE
fcm ci: fix Perl warning on empty status lines

### DIFF
--- a/lib/FCM1/Cm.pm
+++ b/lib/FCM1/Cm.pm
@@ -435,7 +435,7 @@ sub cm_commit {
     LINE:
     for my $line (@status) {
       for my $key (keys(%st_lines_of)) {
-        if ($ST_MATCHER_FOR{$key}->($line)) {
+        if ($line && $ST_MATCHER_FOR{$key}->($line)) {
           push(@{$st_lines_of{$key}}, $line);
           next LINE;
         }
@@ -1815,7 +1815,7 @@ sub _svn_status_get {
         }
     }
     my @options = ($show_updates ? qw{--show-updates} : ());
-    $SVN->stdout(qw{svn status}, @options, @targets);
+    $SVN->stdout(qw{svn status --ignore-externals}, @options, @targets);
 }
 
 # ------------------------------------------------------------------------------

--- a/t/fcm-commit/04-externals.t
+++ b/t/fcm-commit/04-externals.t
@@ -1,0 +1,40 @@
+#!/bin/bash
+# ------------------------------------------------------------------------------
+# (C) British Crown Copyright 2006-14 Met Office.
+#
+# This file is part of FCM, tools for managing and building source code.
+#
+# FCM is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FCM is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FCM. If not, see <http://www.gnu.org/licenses/>.
+# ------------------------------------------------------------------------------
+# Tests for "fcm commit", in a working copy with externals.
+#-------------------------------------------------------------------------------
+. "$(dirname "$0")/test_header"
+#-------------------------------------------------------------------------------
+tests 2
+#-------------------------------------------------------------------------------
+svnadmin create 'foo'
+svnadmin create 'bar'
+svn co -q "file://${PWD}/foo" 'test-work'
+svn ps svn:externals "test-work/bar file://${PWD}/bar" 'test-work'
+svn ci -q -m 'set external' 'test-work'
+svn update 'test-work'
+echo 'Whatever!' >'test-work/whatever.txt'
+svn add 'test-work/whatever.txt'
+export SVN_EDITOR="sed -i 1i\foo"
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}"
+run_pass "${TEST_KEY}" fcm commit --svn-non-interactive 'test-work' <<<'y'
+file_cmp "${TEST_KEY}.err" "${TEST_KEY}.err" <'/dev/null'
+#-------------------------------------------------------------------------------
+exit

--- a/t/fcm-commit/test_header
+++ b/t/fcm-commit/test_header
@@ -32,6 +32,8 @@ function file_cmp() {
         pass $TEST_KEY
         return
     fi
+    ${FCM_TEST_DIFF_CMD:-diff -u} \
+        "${TEST_DIR}/${FILE_ACTUAL}" "${FILE_EXPECT}" >&2
     fail $TEST_KEY
 }
 


### PR DESCRIPTION
`svn status` contains empty lines if the working copy has an external
item.