### PR TITLE
fcm merge: add mergeinfo tests

### DIFF
--- a/t/fcm-merge/00-simple.t
+++ b/t/fcm-merge/00-simple.t
@@ -21,12 +21,38 @@
 #-------------------------------------------------------------------------------
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
-tests 18
+tests 42
 #-------------------------------------------------------------------------------
 setup
 init_repos
 init_merge_branches merge1 merge2 $REPOS_URL
 cd $TEST_DIR/wc
+#-------------------------------------------------------------------------------
+test_mergeinfo "$TEST_KEY_BASE-pre" \
+    $ROOT_URL/branches/dev/Share/merge1 <<__RESULTS__
+begin-prop
+end-prop
+begin-info
+    youngest common ancestor
+    |         last full merge
+    |         |        tip of branch
+    |         |        |         repository path
+
+    1                  9       
+    |                  |       
+       --| |------------         branches/dev/Share/merge1
+      /                        
+     /                         
+  -------| |------------         trunk
+                       |       
+                       9       
+end-info
+begin-eligible
+r5
+end-eligible
+begin-merged
+end-merged
+__RESULTS__
 #-------------------------------------------------------------------------------
 # Tests fcm merge --dry-run
 TEST_KEY=$TEST_KEY_BASE-dry-run
@@ -317,5 +343,34 @@ Added: svn:mergeinfo
 __OUT__
 fi
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+#-------------------------------------------------------------------------------
+test_mergeinfo "$TEST_KEY_BASE-post" \
+    $ROOT_URL/branches/dev/Share/merge1 - <<__RESULTS__
+begin-prop
+/branches/dev/Share/merge1:4-5
+end-prop
+begin-info
+    youngest common ancestor
+    |         last full merge
+    |         |        tip of branch
+    |         |        |         repository path
+
+    1                  9       
+    |                  |       
+       --| |------------         branches/dev/Share/merge1
+      /                        
+     /                         
+  -------| |------------         trunk
+                       |       
+                       9       
+end-info
+begin-eligible
+end-eligible
+begin-merged
+r4
+r5
+end-merged
+__RESULTS__
+#-------------------------------------------------------------------------------
 teardown
 #-------------------------------------------------------------------------------

--- a/t/fcm-merge/00-simple.t
+++ b/t/fcm-merge/00-simple.t
@@ -28,6 +28,7 @@ init_repos
 init_merge_branches merge1 merge2 $REPOS_URL
 cd $TEST_DIR/wc
 #-------------------------------------------------------------------------------
+# Test the various mergeinfo output before merging.
 test_mergeinfo "$TEST_KEY_BASE-pre" \
     $ROOT_URL/branches/dev/Share/merge1 <<__RESULTS__
 begin-prop
@@ -344,6 +345,7 @@ __OUT__
 fi
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
+# Test the various mergeinfo output after merging.
 test_mergeinfo "$TEST_KEY_BASE-post" \
     $ROOT_URL/branches/dev/Share/merge1 - <<__RESULTS__
 begin-prop

--- a/t/fcm-merge/01-complex.t
+++ b/t/fcm-merge/01-complex.t
@@ -30,6 +30,7 @@ export SVN_EDITOR="sed -i 1i\foo"
 cd $TEST_DIR/wc
 svn switch -q $ROOT_URL/branches/dev/Share/merge1
 #-------------------------------------------------------------------------------
+# Test the various mergeinfo output before merging.
 test_mergeinfo "$TEST_KEY_BASE-trunk-into-branch-1-pre" \
     $ROOT_URL/trunk <<__RESULTS__
 begin-prop
@@ -235,6 +236,7 @@ initial trunk import
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
+# Test the various mergeinfo output after merging.
 test_mergeinfo "$TEST_KEY_BASE-trunk-into-branch-1-post" \
     $ROOT_URL/trunk <<__RESULTS__
 begin-prop
@@ -275,6 +277,7 @@ mkdir $TEST_DIR/wc
 svn checkout -q $ROOT_URL/trunk $TEST_DIR/wc
 cd $TEST_DIR/wc
 #-------------------------------------------------------------------------------
+# Test the various mergeinfo output before merging.
 test_mergeinfo "$TEST_KEY_BASE-branch-into-trunk-1-pre" \
     $ROOT_URL/branches/dev/Share/merge1 <<__RESULTS__
 begin-prop
@@ -669,6 +672,7 @@ initial trunk import
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
+# Test the various mergeinfo output after merging.
 test_mergeinfo "$TEST_KEY_BASE-branch-into-trunk-1-post" \
     $ROOT_URL/branches/dev/Share/merge1 <<__RESULTS__
 begin-prop
@@ -707,6 +711,7 @@ svn commit -q -m "Made branch change to add extra feature"
 svn update -q
 svn switch -q $ROOT_URL/trunk
 #-------------------------------------------------------------------------------
+# Test the various mergeinfo output before merging.
 test_mergeinfo "$TEST_KEY_BASE-branch-into-trunk-2-pre" \
     $ROOT_URL/branches/dev/Share/merge1 <<__RESULTS__
 begin-prop
@@ -884,6 +889,7 @@ initial trunk import
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
+# Test the various mergeinfo output after merging.
 test_mergeinfo "$TEST_KEY_BASE-branch-into-trunk-2-post" \
     $ROOT_URL/branches/dev/Share/merge1 <<__RESULTS__
 begin-prop
@@ -925,6 +931,7 @@ echo "# added another line for simple repeat testing" >>$BRANCH_MOD_FILE
 svn commit -q -m "Made branch change for merge repeat test"
 svn update -q
 #------------------------------------------------------------------------------
+# Test the various mergeinfo output before merging.
 test_mergeinfo "$TEST_KEY_BASE-trunk-into-branch-2-pre" \
     $ROOT_URL/trunk <<__RESULTS__
 begin-prop
@@ -1117,6 +1124,7 @@ initial trunk import
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
+# Test the various mergeinfo output after merging.
 test_mergeinfo "$TEST_KEY_BASE-trunk-into-branch-2-post" \
     $ROOT_URL/trunk <<__RESULTS__
 begin-prop
@@ -1155,6 +1163,7 @@ svn commit -q -m "Made branch change - deleted $BRANCH_MOD_FILE, copied $MOD_FIL
 svn update -q
 svn switch -q $ROOT_URL/trunk
 #-------------------------------------------------------------------------------
+# Test the various mergeinfo output before merging.
 test_mergeinfo "$TEST_KEY_BASE-branch-into-trunk-3-pre" \
     $ROOT_URL/branches/dev/Share/merge1 <<__RESULTS__
 begin-prop
@@ -1401,6 +1410,7 @@ initial trunk import
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
+# Test the various mergeinfo output after merging.
 test_mergeinfo "$TEST_KEY_BASE-branch-into-trunk-3-post" \
     $ROOT_URL/branches/dev/Share/merge1 <<__RESULTS__
 begin-prop
@@ -1446,6 +1456,7 @@ echo "Second branch change" >>$BRANCH_2_MOD_FILE
 svn commit -q -m "Made branch change - added to $BRANCH_2_MOD_FILE"
 svn update -q
 #------------------------------------------------------------------------------
+# Test the various mergeinfo output before merging.
 test_mergeinfo "$TEST_KEY_BASE-branch-into-branch-1-pre" \
     $ROOT_URL/branches/dev/Share/merge1 <<__RESULTS__
 begin-prop
@@ -1986,6 +1997,7 @@ initial trunk import
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #------------------------------------------------------------------------------
+# Test the various mergeinfo output after merging.
 test_mergeinfo "$TEST_KEY_BASE-branch-into-branch-1-post" \
     $ROOT_URL/branches/dev/Share/merge1 <<__RESULTS__
 begin-prop

--- a/t/fcm-merge/01-complex.t
+++ b/t/fcm-merge/01-complex.t
@@ -21,16 +21,43 @@
 #-------------------------------------------------------------------------------
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
-tests 90
+tests 234
 #-------------------------------------------------------------------------------
 setup
 init_repos
 init_merge_branches merge1 merge2 $REPOS_URL
 export SVN_EDITOR="sed -i 1i\foo"
 cd $TEST_DIR/wc
+svn switch -q $ROOT_URL/branches/dev/Share/merge1
+#-------------------------------------------------------------------------------
+test_mergeinfo "$TEST_KEY_BASE-trunk-into-branch-1-pre" \
+    $ROOT_URL/trunk <<__RESULTS__
+begin-prop
+end-prop
+begin-info
+    youngest common ancestor
+    |         last full merge
+    |         |        tip of branch
+    |         |        |         repository path
+
+    1                  9       
+    |                  |       
+  -------| |------------         trunk
+     \                         
+      \                        
+       --| |------------         branches/dev/Share/merge1
+                       |       
+                       9       
+end-info
+begin-eligible
+r8
+r9
+end-eligible
+begin-merged
+end-merged
+__RESULTS__
 #-------------------------------------------------------------------------------
 # Tests fcm merge of trunk-into-branch (1)
-svn switch -q $ROOT_URL/branches/dev/Share/merge1
 TEST_KEY=$TEST_KEY_BASE-trunk-into-branch-1-non-root
 cd module
 run_pass "$TEST_KEY" fcm merge --non-interactive trunk
@@ -208,6 +235,34 @@ initial trunk import
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
+test_mergeinfo "$TEST_KEY_BASE-trunk-into-branch-1-post" \
+    $ROOT_URL/trunk <<__RESULTS__
+begin-prop
+/trunk:2-9
+end-prop
+begin-info
+    youngest common ancestor
+    |         last full merge
+    |         |        tip of branch
+    |         |        |         repository path
+
+    1         9        10      
+    |         |        |       
+  -------| |------------         trunk
+     \         \               
+      \         \              
+       --| |------------         branches/dev/Share/merge1
+                       |       
+                       10      
+end-info
+begin-eligible
+end-eligible
+begin-merged
+r8
+r9
+end-merged
+__RESULTS__
+#-------------------------------------------------------------------------------
 # Tests fcm merge of branch-into-trunk (1)
 TEST_KEY=$TEST_KEY_BASE-branch-into-trunk-1
 BRANCH_MOD_FILE=$(find . -type f | sed "/\.svn/d" | sort | head -3| tail -1)
@@ -219,6 +274,35 @@ rm -rf $TEST_DIR/wc
 mkdir $TEST_DIR/wc
 svn checkout -q $ROOT_URL/trunk $TEST_DIR/wc
 cd $TEST_DIR/wc
+#-------------------------------------------------------------------------------
+test_mergeinfo "$TEST_KEY_BASE-branch-into-trunk-1-pre" \
+    $ROOT_URL/branches/dev/Share/merge1 <<__RESULTS__
+begin-prop
+end-prop
+begin-info
+    youngest common ancestor
+    |         last full merge
+    |         |        tip of branch
+    |         |        |         repository path
+
+    1                  11      
+    |                  |       
+       --| |------------         branches/dev/Share/merge1
+      /         /              
+     /         /               
+  -------| |------------         trunk
+              |        |       
+              9        11      
+end-info
+begin-eligible
+r5
+r10
+r11
+end-eligible
+begin-merged
+end-merged
+__RESULTS__
+#-------------------------------------------------------------------------------
 run_pass "$TEST_KEY" fcm merge --non-interactive branches/dev/Share/merge1
 if $SVN_VERSION_IS_16; then
     file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
@@ -585,6 +669,36 @@ initial trunk import
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
+test_mergeinfo "$TEST_KEY_BASE-branch-into-trunk-1-post" \
+    $ROOT_URL/branches/dev/Share/merge1 <<__RESULTS__
+begin-prop
+/branches/dev/Share/merge1:4-11
+end-prop
+begin-info
+    youngest common ancestor
+    |         last full merge
+    |         |        tip of branch
+    |         |        |         repository path
+
+    1         11       12      
+    |         |        |       
+       --| |------------         branches/dev/Share/merge1
+      /        \               
+     /          \              
+  -------| |------------         trunk
+                       |       
+                       12      
+end-info
+begin-eligible
+end-eligible
+begin-merged
+r4
+r5
+r10
+r11
+end-merged
+__RESULTS__
+#-------------------------------------------------------------------------------
 # Tests fcm merge of branch-into-trunk (2)
 svn switch -q $ROOT_URL/branches/dev/Share/merge1
 MOD_FILE=$(find . -type f | sed "/\.svn/d" | sort | head -4 | tail -1)
@@ -592,6 +706,38 @@ echo "call_extra_feature()" >>$MOD_FILE
 svn commit -q -m "Made branch change to add extra feature"
 svn update -q
 svn switch -q $ROOT_URL/trunk
+#-------------------------------------------------------------------------------
+test_mergeinfo "$TEST_KEY_BASE-branch-into-trunk-2-pre" \
+    $ROOT_URL/branches/dev/Share/merge1 <<__RESULTS__
+begin-prop
+/branches/dev/Share/merge1:4-11
+end-prop
+begin-info
+    youngest common ancestor
+    |         last full merge
+    |         |        tip of branch
+    |         |        |         repository path
+
+    1         11       13      
+    |         |        |       
+       --| |------------         branches/dev/Share/merge1
+      /        \               
+     /          \              
+  -------| |------------         trunk
+                       |       
+                       13      
+end-info
+begin-eligible
+r13
+end-eligible
+begin-merged
+r4
+r5
+r10
+r11
+end-merged
+__RESULTS__
+#-------------------------------------------------------------------------------
 TEST_KEY=$TEST_KEY_BASE-branch-into-trunk-2
 run_pass "$TEST_KEY" fcm merge --non-interactive branches/dev/Share/merge1
 if $SVN_VERSION_IS_16; then
@@ -738,15 +884,79 @@ initial trunk import
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
+test_mergeinfo "$TEST_KEY_BASE-branch-into-trunk-2-post" \
+    $ROOT_URL/branches/dev/Share/merge1 <<__RESULTS__
+begin-prop
+/branches/dev/Share/merge1:4-13
+end-prop
+begin-info
+    youngest common ancestor
+    |         last full merge
+    |         |        tip of branch
+    |         |        |         repository path
+
+    1         13       14      
+    |         |        |       
+       --| |------------         branches/dev/Share/merge1
+      /        \               
+     /          \              
+  -------| |------------         trunk
+                       |       
+                       14      
+end-info
+begin-eligible
+end-eligible
+begin-merged
+r4
+r5
+r10
+r11
+r13
+end-merged
+__RESULTS__
+#-------------------------------------------------------------------------------
 # Tests fcm merge of trunk-into-branch (2)
 echo "# trunk modification" >>$MOD_FILE
 svn commit -q -m "Made trunk change - a simple edit of $MOD_FILE"
 svn update -q
 svn switch -q $ROOT_URL/branches/dev/Share/merge1
-TEST_KEY=$TEST_KEY_BASE-trunk-into-branch-2
+
 echo "# added another line for simple repeat testing" >>$BRANCH_MOD_FILE
 svn commit -q -m "Made branch change for merge repeat test"
 svn update -q
+#------------------------------------------------------------------------------
+test_mergeinfo "$TEST_KEY_BASE-trunk-into-branch-2-pre" \
+    $ROOT_URL/trunk <<__RESULTS__
+begin-prop
+/trunk:2-9
+end-prop
+begin-info
+    youngest common ancestor
+    |         last full merge
+    |         |        tip of branch
+    |         |        |         repository path
+
+    1                  16      
+    |                  |       
+  -------| |------------         trunk
+     \          /              
+      \        /               
+       --| |------------         branches/dev/Share/merge1
+              |        |       
+              13       16      
+end-info
+begin-eligible
+r12
+r14
+r15
+end-eligible
+begin-merged
+r8
+r9
+end-merged
+__RESULTS__
+#------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-trunk-into-branch-2
 run_pass "$TEST_KEY" fcm merge --non-interactive trunk
 if $SVN_VERSION_IS_16; then
     file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
@@ -907,12 +1117,78 @@ initial trunk import
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
+test_mergeinfo "$TEST_KEY_BASE-trunk-into-branch-2-post" \
+    $ROOT_URL/trunk <<__RESULTS__
+begin-prop
+/trunk:2-15
+end-prop
+begin-info
+    youngest common ancestor
+    |         last full merge
+    |         |        tip of branch
+    |         |        |         repository path
+
+    1         15       17      
+    |         |        |       
+  -------| |------------         trunk
+     \         \               
+      \         \              
+       --| |------------         branches/dev/Share/merge1
+                       |       
+                       17      
+end-info
+begin-eligible
+end-eligible
+begin-merged
+r8
+r9
+r12
+r14
+r15
+end-merged
+__RESULTS__
+#-------------------------------------------------------------------------------
 # Tests fcm merge of branch-into-trunk (3)
 svn delete -q $BRANCH_MOD_FILE
 svn copy -q $MOD_FILE $MOD_FILE.add
 svn commit -q -m "Made branch change - deleted $BRANCH_MOD_FILE, copied $MOD_FILE"
 svn update -q
 svn switch -q $ROOT_URL/trunk
+#-------------------------------------------------------------------------------
+test_mergeinfo "$TEST_KEY_BASE-branch-into-trunk-3-pre" \
+    $ROOT_URL/branches/dev/Share/merge1 <<__RESULTS__
+begin-prop
+/branches/dev/Share/merge1:4-13
+end-prop
+begin-info
+    youngest common ancestor
+    |         last full merge
+    |         |        tip of branch
+    |         |        |         repository path
+
+    1                  18      
+    |                  |       
+       --| |------------         branches/dev/Share/merge1
+      /         /              
+     /         /               
+  -------| |------------         trunk
+              |        |       
+              15       18      
+end-info
+begin-eligible
+r16
+r17
+r18
+end-eligible
+begin-merged
+r4
+r5
+r10
+r11
+r13
+end-merged
+__RESULTS__
+#-------------------------------------------------------------------------------
 TEST_KEY=$TEST_KEY_BASE-branch-into-trunk-3
 run_pass "$TEST_KEY" fcm merge --non-interactive branches/dev/Share/merge1
 if $SVN_VERSION_IS_16; then
@@ -1125,8 +1401,41 @@ initial trunk import
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
+test_mergeinfo "$TEST_KEY_BASE-branch-into-trunk-3-post" \
+    $ROOT_URL/branches/dev/Share/merge1 <<__RESULTS__
+begin-prop
+/branches/dev/Share/merge1:4-18
+end-prop
+begin-info
+    youngest common ancestor
+    |         last full merge
+    |         |        tip of branch
+    |         |        |         repository path
+
+    1         18       19      
+    |         |        |       
+       --| |------------         branches/dev/Share/merge1
+      /        \               
+     /          \              
+  -------| |------------         trunk
+                       |       
+                       19      
+end-info
+begin-eligible
+end-eligible
+begin-merged
+r4
+r5
+r10
+r11
+r13
+r16
+r17
+r18
+end-merged
+__RESULTS__
+#-------------------------------------------------------------------------------
 # Tests fcm merge of branch-into-branch (1)
-TEST_KEY=$TEST_KEY_BASE-branch-into-branch-1
 cd $TEST_DIR
 rm -rf $TEST_DIR/wc
 mkdir $TEST_DIR/wc
@@ -1136,6 +1445,40 @@ BRANCH_2_MOD_FILE=$(find . -type f | sed "/\.svn/d" | sort | head -3| tail -1)
 echo "Second branch change" >>$BRANCH_2_MOD_FILE
 svn commit -q -m "Made branch change - added to $BRANCH_2_MOD_FILE"
 svn update -q
+#------------------------------------------------------------------------------
+test_mergeinfo "$TEST_KEY_BASE-branch-into-branch-1-pre" \
+    $ROOT_URL/branches/dev/Share/merge1 <<__RESULTS__
+begin-prop
+end-prop
+begin-info
+    youngest common ancestor
+    |         last full merge
+    |         |        tip of branch
+    |         |        |         repository path
+
+    1                  20      
+    |                  |       
+       --| |------------         branches/dev/Share/merge1
+  ... /                        
+      \                        
+       --| |------------         branches/dev/Share/merge2
+                       |       
+                       20      
+end-info
+begin-eligible
+r5
+r10
+r11
+r13
+r16
+r17
+r18
+end-eligible
+begin-merged
+end-merged
+__RESULTS__
+#------------------------------------------------------------------------------
+TEST_KEY=$TEST_KEY_BASE-branch-into-branch-1
 run_pass "$TEST_KEY" fcm merge $ROOT_URL/branches/dev/Share/merge1 <<__IN__
 13
 y
@@ -1642,5 +1985,42 @@ initial trunk import
 ------------------------------------------------------------------------
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+#------------------------------------------------------------------------------
+test_mergeinfo "$TEST_KEY_BASE-branch-into-branch-1-post" \
+    $ROOT_URL/branches/dev/Share/merge1 <<__RESULTS__
+begin-prop
+/branches/dev/Share/merge1:4-13
+/trunk:2-9
+end-prop
+begin-info
+    youngest common ancestor
+    |         last full merge
+    |         |        tip of branch
+    |         |        |         repository path
+
+    1         13       21      
+    |         |        |       
+       --| |------------         branches/dev/Share/merge1
+  ... /        \               
+      \         \              
+       --| |------------         branches/dev/Share/merge2
+                       |       
+                       21      
+end-info
+begin-eligible
+r16
+r17
+r18
+end-eligible
+begin-merged
+r4
+r5
+r10
+r11
+r13
+end-merged
+__RESULTS__
+
+#-------------------------------------------------------------------------------
 teardown
 #-------------------------------------------------------------------------------

--- a/t/fcm-merge/test_header
+++ b/t/fcm-merge/test_header
@@ -28,7 +28,7 @@ function file_cmp() {
     local TEST_KEY=$1
     local FILE_ACTUAL=$2
     local FILE_EXPECT=${3:--}
-    if cmp $TEST_DIR/$FILE_ACTUAL $FILE_EXPECT; then
+    if xxdiff -D $TEST_DIR/$FILE_ACTUAL $FILE_EXPECT; then
         pass $TEST_KEY
         return
     fi
@@ -208,6 +208,44 @@ function run_fail() {
         return
     fi
     pass $TEST_KEY
+}
+
+function get_results() {
+    local RESULT_KEY=$1
+    local RESULTS_FILE=$2
+    local BEGIN="^begin-$RESULT_KEY$"
+    local END="^end-$RESULT_KEY$"
+    local RESULTS_TEMP=$(mktemp)
+    sed -n "/$BEGIN/,/$END/{/$BEGIN\|$END/d; p;}" $RESULTS_FILE >$RESULTS_TEMP
+    echo $RESULTS_TEMP
+}
+
+function test_mergeinfo() {
+    local TEST_INFO_NAME="$1-svn-mergeinfo"
+    local DIFF_BRANCH=$2
+    local INPUT_RESULTS_FILE=${3:--}
+    local RESULTS_FILE=$(mktemp)
+    cat "$INPUT_RESULTS_FILE" > "$RESULTS_FILE"
+    # Test svn:mergeinfo property.
+    TEST_KEY=$TEST_INFO_NAME-prop
+    run_pass "$TEST_KEY" svn propget svn:mergeinfo .
+    file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <$(get_results prop $RESULTS_FILE)
+    file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+    # Test svn mergeinfo output.
+    TEST_KEY=$TEST_INFO_NAME-info
+    run_pass "$TEST_KEY" svn mergeinfo $DIFF_BRANCH
+    file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <$(get_results info $RESULTS_FILE)    
+    file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+    # Test svn mergeinfo show-revs eligible before merge.
+    TEST_KEY=$TEST_INFO_NAME-show-revs-eligible
+    run_pass "$TEST_KEY" svn mergeinfo --show-revs eligible $DIFF_BRANCH
+    file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <$(get_results eligible $RESULTS_FILE)        
+    file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
+    # Test svn mergeinfo show-revs merged before merge.
+    TEST_KEY=$TEST_INFO_NAME-show-revs-merged
+    run_pass "$TEST_KEY" svn mergeinfo --show-revs merged $DIFF_BRANCH
+    file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <$(get_results merged $RESULTS_FILE)            
+    file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 }
 
 function setup() {

--- a/t/fcm-merge/test_header
+++ b/t/fcm-merge/test_header
@@ -28,7 +28,7 @@ function file_cmp() {
     local TEST_KEY=$1
     local FILE_ACTUAL=$2
     local FILE_EXPECT=${3:--}
-    if xxdiff -D $TEST_DIR/$FILE_ACTUAL $FILE_EXPECT; then
+    if cmp $TEST_DIR/$FILE_ACTUAL $FILE_EXPECT; then
         pass $TEST_KEY
         return
     fi


### PR DESCRIPTION
This adds some `svn mergeinfo` and `svn:mergeinfo` tests to `fcm merge`.

This helps document current behaviour for #69.

@matthewrmshin, please review.