### PR TITLE
fcm make: build: fix external case in ext-iface

### DIFF
--- a/lib/FCM/System/Make/Build/Task/ExtractInterface.pm
+++ b/lib/FCM/System/Make/Build/Task/ExtractInterface.pm
@@ -306,7 +306,7 @@ sub _process {
     # Attribute Statements
     ($name) = $statement->{value} =~ $RE{TYPE_ATTR};
     if ($name) {
-        $statement->{name} = $name;
+        $statement->{name} = lc($name);
         $statement->{type} = 'attr';
     }
 }
@@ -407,7 +407,7 @@ STATEMENT:
         }
         if ($statement->{type} eq 'attr') {
             my ($spec, @tokens) = ($statement->{value} =~ /$RE{NAME_COMP}/g);
-            if (grep { exists($token_set{$_}) } @tokens) {
+            if (grep { exists($token_set{lc($_)}) } @tokens) {
                 for my $token (@tokens) {
                     $token_set{$token} = 1;
                 }

--- a/t/fcm-make/02-build-ext-iface/expected/t1.interface
+++ b/t/fcm-make/02-build-ext-iface/expected/t1.interface
@@ -65,6 +65,12 @@ end subroutine sub_with_renamed_import
 subroutine sub_with_external(proc)
 external proc
 end subroutine sub_with_external
+subroutine sub_with_external2(PROC)
+external proc
+end subroutine sub_with_external2
+subroutine sub_with_external3(proc)
+external PROC
+end subroutine sub_with_external3
 subroutine sub_with_end()
 end subroutine sub_with_end
 end interface

--- a/t/fcm-make/02-build-ext-iface/src/t1.f90
+++ b/t/fcm-make/02-build-ext-iface/src/t1.f90
@@ -147,6 +147,20 @@ external proc
 call proc()
 end subroutine sub_with_external
 
+! A subroutine with an external argument, 2
+! https://github.com/metomi/fcm/issues/175
+subroutine sub_with_external2(PROC)
+external proc
+call proc()
+end subroutine sub_with_external2
+
+! A subroutine with an external argument, 3
+! https://github.com/metomi/fcm/issues/175
+subroutine sub_with_external3(proc)
+external PROC
+call proc()
+end subroutine sub_with_external3
+
 ! A subroutine with a variable named "end"
 subroutine sub_with_end()
 integer :: end


### PR DESCRIPTION
Arguments to Fortran `EXTERNAL` statements were being matched in
case-sensitive mode. This change fixes the problem.

Fix #175.