### PR TITLE
fcm make: .fcm-make/log symlink should be relative

### DIFF
--- a/lib/FCM/System/Make.pm
+++ b/lib/FCM/System/Make.pm
@@ -31,9 +31,10 @@ use FCM::System::Make::Mirror;
 use FCM::System::Make::Preprocess;
 use FCM::System::Make::Share::Config;
 use FCM::System::Make::Share::Dest;
+use File::Basename qw{basename};
+use File::Copy qw{copy};
 use File::Path qw{rmtree};
 use File::Spec::Functions qw{catfile};
-use File::Copy qw{copy};
 use File::Temp;
 use POSIX qw{strftime};
 use Sys::Hostname qw{hostname};
@@ -138,7 +139,7 @@ sub _dest_init {
     my $now = strftime("%Y%m%dT%H%M%S", gmtime());
     my $log = $attrib_ref->{shared_util_of}{dest}->path($m_ctx, 'sys-log');
     my $log_actual = sprintf("%s-%s", $log, $now);
-    _symlink($log_actual, $log);
+    _symlink(basename($log_actual), $log);
     (       close($attrib_ref->{handle_log})
         &&  copy($attrib_ref->{handle_log}->filename(), $log)
         &&  open(my $handle_log, '>>', $log)

--- a/t/fcm-make/10-log.t
+++ b/t/fcm-make/10-log.t
@@ -17,11 +17,11 @@
 # You should have received a copy of the GNU General Public License
 # along with FCM. If not, see <http://www.gnu.org/licenses/>.
 #-------------------------------------------------------------------------------
-# Basic tests for "fcm make".
+# Tests "fcm make", generation of log files.
 #-------------------------------------------------------------------------------
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
-tests 7
+tests 11
 cp -r $TEST_SOURCE_DIR/$TEST_KEY_BASE/* .
 #-------------------------------------------------------------------------------
 TEST_KEY="$TEST_KEY_BASE"
@@ -40,6 +40,11 @@ if [[ $(ls .fcm-make/log-* | wc -l) == 1 ]]; then
 else
     fail "$TEST_KEY-n-logs"
 fi
+run_pass "$TEST_KEY-symlink-1" \
+    test "$(readlink 'fcm-make.log')" '=' '.fcm-make/log'
+run_pass "$TEST_KEY-symlink-2" \
+    test "$(readlink '.fcm-make/log')" \
+    '=' "$(cd '.fcm-make'; ls 'log-'* | sort | tail -1)"
 #-------------------------------------------------------------------------------
 TEST_KEY="$TEST_KEY_BASE-incr"
 sleep 1
@@ -50,5 +55,10 @@ if [[ $(ls .fcm-make/log-* | wc -l) == 2 ]]; then
 else
     fail "$TEST_KEY-n-logs"
 fi
+run_pass "$TEST_KEY-symlink-1" \
+    test "$(readlink 'fcm-make.log')" '=' '.fcm-make/log'
+run_pass "$TEST_KEY-symlink-2" \
+    test "$(readlink '.fcm-make/log')" \
+    '=' "$(cd '.fcm-make'; ls 'log-'* | sort | tail -1)"
 #-------------------------------------------------------------------------------
 exit 0


### PR DESCRIPTION
Absolute path makes it harder to relocate the directory.