### PR TITLE
source file find: ignore hidden only if under $ns

### DIFF
--- a/lib/FCM/System/Make/Build.pm
+++ b/lib/FCM/System/Make/Build.pm
@@ -404,13 +404,14 @@ sub _sources_locate_by_find {
             if (-d $path_found) {
                 return;
             }
-            my ($vol, $dir_name, $base) = splitpath($path_found);
-            for my $name (splitdir($dir_name), $base) {
-                if (index($name, q{.}) == 0) {
-                    return; # ignore Unix hidden/system files
+            my $ns = abs2rel($path_found, $path);
+            if ($ns ne q{.}) {
+                for my $name (split(q{/}, $ns)) {
+                    if (index($name, q{.}) == 0) {
+                        return; # ignore Unix hidden/system files
+                    }
                 }
             }
-            my $ns = abs2rel($path_found, $path);
             if ($key) {
                 $ns = $UTIL->ns_cat($key, $ns);
             }

--- a/lib/FCM/Util/Locator/FS.pm
+++ b/lib/FCM/Util/Locator/FS.pm
@@ -67,15 +67,16 @@ sub _find {
         sub {
             $found ||= 1;
             my $path = $File::Find::name;
-            my ($vol, $dir_name, $base) = File::Spec->splitpath($path);
-            for my $name (File::Spec->splitdir($dir_name), $base) {
-                if (index($name, q{.}) == 0) {
-                    return; # ignore Unix hidden/system files
-                }
-            }
             my $ns = File::Spec->abs2rel($path, $value);
             if ($ns eq q{.}) {
                 $ns = q{};
+            }
+            else {
+                for my $name (split(q{/}, $ns)) {
+                    if (index($name, q{.}) == 0) {
+                        return; # ignore Unix hidden/system files
+                    }
+                }
             }
             my $last_mod_time = (-l $path ? lstat($path) : stat($path))[9];
             $callback->(

--- a/t/fcm-make/39-build-source-with-dot.t
+++ b/t/fcm-make/39-build-source-with-dot.t
@@ -1,0 +1,54 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2006-15 Met Office.
+#
+# This file is part of FCM, tools for managing and building source code.
+#
+# FCM is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FCM is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FCM. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Tests "fcm make", build, source path is under a hidden directory.
+#-------------------------------------------------------------------------------
+. "$(dirname "$0")/test_header"
+tests 5
+#-------------------------------------------------------------------------------
+mkdir -p 'src/.singularity'
+cat >'src/.singularity/hello.f90' <<'__FORTRAN__'
+program hello
+write(*, '(a)') 'No information!'
+end program hello
+__FORTRAN__
+#-------------------------------------------------------------------------------
+cat >'fcm-make.cfg' <<'__CFG__'
+steps=build
+build.source=$HERE/src
+build.prop{file-ext.bin}=.bin
+build.target=hello.bin
+__CFG__
+run_fail "${TEST_KEY_BASE}-tail" fcm make --new
+run_fail "${TEST_KEY_BASE}-tail.bin" './build/bin/hello.bin'
+
+cat >'fcm-make.cfg' <<'__CFG__'
+steps=build
+build.source=$HERE/src/.singularity
+build.prop{file-ext.bin}=.bin
+build.target=hello.bin
+__CFG__
+run_pass "${TEST_KEY_BASE}-head" fcm make --new
+run_pass "${TEST_KEY_BASE}-head.bin" './build/bin/hello.bin'
+file_cmp "${TEST_KEY_BASE}-head.bin.out" \
+    "${TEST_KEY_BASE}-head.bin.out" <<'__OUT__'
+No information!
+__OUT__
+#-------------------------------------------------------------------------------
+exit

--- a/t/fcm-make/40-extract-fs-source-with-dot.t
+++ b/t/fcm-make/40-extract-fs-source-with-dot.t
@@ -1,0 +1,59 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2006-15 Met Office.
+#
+# This file is part of FCM, tools for managing and building source code.
+#
+# FCM is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FCM is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FCM. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Tests "fcm make", extract, FS source path is under a hidden directory.
+#-------------------------------------------------------------------------------
+. "$(dirname "$0")/test_header"
+tests 5
+#-------------------------------------------------------------------------------
+# dot path name under source tree
+mkdir -p 'bubble/.com'
+cat >'bubble/.com/burst.f90' <<'__FORTRAN__'
+program burst
+write(*, '(a)') 'Burst!'
+end program burst
+__FORTRAN__
+cat >'fcm-make.cfg' <<'__CFG__'
+steps=extract
+extract.ns = bubble
+extract.location[bubble]=$HERE/bubble
+__CFG__
+run_pass "${TEST_KEY_BASE}-tail" fcm make --new
+run_fail "${TEST_KEY_BASE}-tail-find" find 'extract' -type f
+#-------------------------------------------------------------------------------
+# dot path name above source tree
+mkdir -p '.com/bubble'
+cat >'.com/bubble/burst.f90' <<'__FORTRAN__'
+program burst
+write(*, '(a)') 'Burst!'
+end program burst
+__FORTRAN__
+cat >'fcm-make.cfg' <<'__CFG__'
+steps=extract
+extract.ns = bubble
+extract.location[bubble]=$HERE/.com/bubble
+__CFG__
+run_pass "${TEST_KEY_BASE}-head" fcm make --new
+run_pass "${TEST_KEY_BASE}-head-find" find 'extract' -type f
+file_cmp "${TEST_KEY_BASE}-head-find.out" \
+    "${TEST_KEY_BASE}-head-find.out" <<'__OUT__'
+extract/bubble/burst.f90
+__OUT__
+#-------------------------------------------------------------------------------
+exit


### PR DESCRIPTION
This allows users to specify a source file path name with a leading dot
in the directory.

Fix #180.