### PR TITLE
fcm make: fix --directory=PATH documentation

### DIFF
--- a/doc/user_guide/command_ref.html
+++ b/doc/user_guide/command_ref.html
@@ -1347,9 +1347,8 @@ browser = konqueror
 
         <dt><code>--directory=PATH, -C PATH</code></dt>
 
-        <dd>Specifies the path to the destination. (default=<samp>$PWD</samp>
-        or whatever is specified in the <code>dest</code> setting in the
-        configuration file)</dd>
+        <dd>Change directory to <var>PATH</var> before doing anything.
+        (default=<var>$PWD</var>)</dd>
 
         <dt><code>--ignore-lock</code></dt>
 

--- a/lib/FCM/CLI/fcm-make.pod
+++ b/lib/FCM/CLI/fcm-make.pod
@@ -28,8 +28,7 @@ current working directory)
 
 =item --directory=PATH, -C PATH
 
-Specify the path to the destination. (default = $PWD or whatever is specified
-in the "dest" setting in the configuration file)
+Change directory to C<PATH> before doing anything. (default = $PWD)
 
 =item --ignore-lock
 


### PR DESCRIPTION
The command changes directory to PATH before doing anything.