### PR TITLE
fcm make: new --archive option

### DIFF
--- a/doc/user_guide/annex_cfg.html
+++ b/doc/user_guide/annex_cfg.html
@@ -972,7 +972,21 @@ build.prop{fc.libs}[myprog.exe] = netcdf grib
 
     <dt id="make.build.prop.ar.flags">ar.flags</dt>
 
+    <dd>If a list of values is specified, the system will not inherit sources
+    with the name-spaces matching the specified values. If the value is a
+    <samp>*</samp>, the system will not inherit any sources.</dd>
     <dd>The options used by the archive command. (default=<samp>rs</samp>)</dd>
+
+    <dt id=
+    "make.build.prop.archive-ok-target-category">archive-ok-target-category
+    *</dt>
+
+    <dd>If <code>fcm make</code> is invoked with the <code>--archive</code>
+    option, sub-directories in categories containing intermediate build files
+    will be put into TAR-GZIP files. E.g. with the default setting,
+    <samp>include/</samp> and <samp>o/</samp> will become
+    <samp>include.tar.gz</samp> and <samp>o.tar.gz</samp> respectively.
+    (default=<samp>include o</samp>)</dd>
 
     <dt id="make.build.prop.cc">cc</dt>
 

--- a/doc/user_guide/command_ref.html
+++ b/doc/user_guide/command_ref.html
@@ -1334,6 +1334,17 @@ browser = konqueror
 
     <dd>
       <dl>
+        <dt><code>--archive, -a</code></dt>
+
+        <dd>Switch on archive mode. In archive mode, intermediate files will be
+        put into TAR-GZIP archives on completion, e.g. extract system:
+        <samp>.fcm-make/cache/extract/</samp>, and build system:
+        <samp>build/include/</samp> and <samp>build/o/</samp>.
+
+          <p>The archive mode is not suitable for a make that will be inherited
+          or used by other makes.</p>
+        </dd>
+
         <dt><code>--config-file-path=PATH, -F PATH</code></dt>
 
         <dd>Specifies paths for searching configuration files specified in

--- a/doc/user_guide/make.html
+++ b/doc/user_guide/make.html
@@ -167,8 +167,12 @@ build/...
   <dl>
     <dt><samp>.fcm-make/cache/</samp></dt>
 
-    <dd>An area for caching non-local items.  E.g.  the extract system exports
-    source trees from the version control system into this cache.</dd>
+    <dd>An area for caching non-local items. E.g. the extract system exports
+    source trees from the version control system into this cache. If <code>fcm
+    make</code> is invoked with the <code>--archive</code> option, contents in
+    this directory will be compressed into TAR-GZIP files, e.g.
+    <samp>.fcm-make/cache/extract/</samp> will become
+    <samp>.fcm-make/cache/extract.tar.gz</samp>.</dd>
 
     <dt><samp>fcm-make-as-parsed.cfg -&gt;
     .fcm-make/config-as-parsed.cfg</samp></dt>
@@ -939,6 +943,14 @@ build/o/...
 
   <p>Sub-directories are only created as necessary, so you may not find all of
   the above in your destination tree.</p>
+
+  <p>If <code>fcm make</code> is invoked with the <code>--archive</code> option,
+  sub-directories in categories containing intermediate build files (or any
+  category specified in the <a href=
+  "#make.build.prop.archive-ok-target-category">archive-ok-target-category</a>
+  property) will be put into TAR-GZIP files. E.g. with the default setting,
+  <samp>include/</samp> and <samp>o/</samp> will become
+  <samp>include.tar.gz</samp> and <samp>o.tar.gz</samp> respectively.</p>
 
   <p>To use a different compiler and/or compiler options for Fortran/C/C++, you
   use the <a href="annex_cfg.html#make.build.prop">build.prop</a> declaration to

--- a/lib/FCM/CLI/Parser.pm
+++ b/lib/FCM/CLI/Parser.pm
@@ -158,15 +158,16 @@ our %OPTIONS_FOR = (
     $HELP_APP       => [@OPTION_OF{qw{quiet verbose}}],
     'keyword-print' => [@OPTION_OF{qw{verbose}}],
     'loc-layout'    => [@OPTION_OF{qw{verbose}}],
-    'merge'         => [@OPTION_OF{
-        qw{auto-log custom dry-run non-interactive quiet reverse revision verbose}
-    }],
-    'mkpatch'       => [@OPTION_OF{qw{exclude organisation revision}}],
     'make'          => [@OPTION_OF{
-        qw{ directory ignore-lock jobs config-file config-file-path name new
-            quiet verbose
+        qw{ archive directory ignore-lock jobs config-file config-file-path name
+            new quiet verbose
         }
     }],
+    'merge'         => [@OPTION_OF{
+        qw{ auto-log custom dry-run non-interactive quiet reverse revision
+            verbose}
+    }],
+    'mkpatch'       => [@OPTION_OF{qw{exclude organisation revision}}],
     'project-create'=> [@OPTION_OF{
         qw{non-interactive password svn-non-interactive}
     }],

--- a/lib/FCM/CLI/fcm-make.pod
+++ b/lib/FCM/CLI/fcm-make.pod
@@ -17,6 +17,16 @@ configuration file.
 
 =over 4
 
+=item --archive, -a
+
+Switch on archive mode. In archive mode, intermediate files will be put into
+TAR-GZIP archives on completion, e.g. extract system:
+C<.fcm-make/cache/extract/>, and build system: C<build/include/> and
+C<build/o/>.
+
+The archive mode is not suitable for a make that will be inherited or used by
+other makes.
+
 =item --config-file-path=PATH, -F PATH
 
 Specify paths for searching configuration files specified in relative paths.

--- a/t/fcm-make/46-archive-mode.t
+++ b/t/fcm-make/46-archive-mode.t
@@ -1,0 +1,111 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2006-15 Met Office.
+#
+# This file is part of FCM, tools for managing and building source code.
+#
+# FCM is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FCM is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FCM. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Tests for "fcm make --archive"
+#-------------------------------------------------------------------------------
+. "$(dirname "$0")/test_header"
+tests 11
+#-------------------------------------------------------------------------------
+# Create a repository to extract
+svnadmin create 'repos'
+T_REPOS="file://${PWD}/repos"
+mkdir 't'
+cat >'t/hello.f90' <<'__FORTRAN__'
+program hello
+use world_mod, only: world
+write(*, '(a,1x,a)') 'Hello', world
+end program hello
+__FORTRAN__
+cat >'t/world_mod.f90' <<'__FORTRAN__'
+module world_mod
+character(*), parameter :: world = 'Earth'
+end module world_mod
+__FORTRAN__
+svn import --no-auth-cache -q -m'Test' t "${T_REPOS}/hello/trunk"
+rm -r 't'
+
+# Create a fcm-make.cfg to do some extract and build
+cat >'fcm-make.cfg' <<__CFG__
+steps = extract build
+extract.ns = hello
+extract.location{primary}[hello] = ${T_REPOS}/hello
+build.target{task} = link
+build.prop{file-ext.bin} =
+__CFG__
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}-on-new"
+run_pass "${TEST_KEY}" fcm make -a
+find '.fcm-make/cache' 'build' -type f | sort >"${TEST_KEY}.find"
+file_cmp "${TEST_KEY}.find" "${TEST_KEY}.find" <<'__FIND__'
+.fcm-make/cache/extract.tar.gz
+build/bin/hello
+build/include.tar.gz
+build/o.tar.gz
+__FIND__
+
+touch 'new'
+sleep 1
+
+TEST_KEY="${TEST_KEY_BASE}-on-incr"
+run_pass "${TEST_KEY}" fcm make -a
+find '.fcm-make/cache' 'build' -type f -newer 'new' \
+    | sort >"${TEST_KEY}.find.new"
+file_cmp "${TEST_KEY}.find.new" "${TEST_KEY}.find.new" <<'__FIND__'
+.fcm-make/cache/extract.tar.gz
+build/include.tar.gz
+build/o.tar.gz
+__FIND__
+find '.fcm-make/cache' 'build' -type f '!' -newer 'new' \
+    | sort >"${TEST_KEY}.find.old"
+file_cmp "${TEST_KEY}.find.old" "${TEST_KEY}.find.old" <<'__FIND__'
+build/bin/hello
+__FIND__
+
+TEST_KEY="${TEST_KEY_BASE}-on-incr-build-o"
+run_pass "${TEST_KEY}" \
+    fcm make -a 'build.prop{archive-ok-target-category}=o'
+find '.fcm-make/cache' 'build' -type f -newer 'new' \
+    | sort >"${TEST_KEY}.find.new"
+file_cmp "${TEST_KEY}.find.new" "${TEST_KEY}.find.new" <<'__FIND__'
+.fcm-make/cache/extract.tar.gz
+build/o.tar.gz
+__FIND__
+find '.fcm-make/cache' 'build' -type f '!' -newer 'new' \
+    | sort >"${TEST_KEY}.find.old"
+file_cmp "${TEST_KEY}.find.old" "${TEST_KEY}.find.old" <<'__FIND__'
+build/bin/hello
+build/include/world_mod.mod
+__FIND__
+
+run_pass "${TEST_KEY_BASE}-off" fcm make
+find '.fcm-make/cache' 'build' -type f -newer 'new' \
+    | sort >"${TEST_KEY}.find.new"
+file_cmp "${TEST_KEY}.find.new" "${TEST_KEY}.find.new" <'/dev/null'
+find '.fcm-make/cache' 'build' -type f '!' -newer 'new' \
+    | sort >"${TEST_KEY}.find.old"
+file_cmp "${TEST_KEY}.find.old" "${TEST_KEY}.find.old" <<'__FIND__'
+.fcm-make/cache/extract/hello/0/hello.f90
+.fcm-make/cache/extract/hello/0/world_mod.f90
+build/bin/hello
+build/include/world_mod.mod
+build/o/hello.o
+build/o/world_mod.o
+__FIND__
+#-------------------------------------------------------------------------------
+exit 0


### PR DESCRIPTION
If archive mode is specified, TAR-GZIP these items by default:
* `.fcm-make/cache/extract/`
* `build/include/`
* `build/o/`

The archive-OK categories for the sub-directories under `build/` are configurable.

Related to #185, #189 and metomi/rose#1621.

@benfitzpatrick please review. This should be the final piece of the puzzle.