### PR TITLE
fcm (b)diff -g: don't lock client

### DIFF
--- a/lib/FCM/CLI/Parser.pm
+++ b/lib/FCM/CLI/Parser.pm
@@ -102,7 +102,10 @@ our %HOOK_BEFORE_FOR = (
     'delete' => _get_code_to_match($OPTION_OF{check}),
     'diff'   => sub {
         _get_code_to_replace(
-            $OPTION_OF{graphical}, [qw{--diff-cmd fcm_graphic_diff}]
+            $OPTION_OF{graphical}, [qw{
+                --config-option config:working-copy:exclusive-locking-clients=
+                --diff-cmd fcm_graphic_diff
+            }]
         )->(@_);
         _get_code_to_replace($OPTION_OF{summarize}, ['--summarize'])->(@_);
         _get_code_to_match($OPTION_OF{branch})->(@_);

--- a/lib/FCM1/Cm.pm
+++ b/lib/FCM1/Cm.pm
@@ -286,7 +286,10 @@ sub cm_branch_diff {
     local(%ENV) = %ENV;
     $ENV{FCM_GRAPHIC_DIFF} ||= $UTIL->external_cfg_get('graphic-diff');
     my @diff_cmd
-        = $option_ref->{graphical}  ? (qw{--diff-cmd fcm_graphic_diff})
+        = $option_ref->{graphical}  ? (qw{
+            --config-option config:working-copy:exclusive-locking-clients=
+            --diff-cmd fcm_graphic_diff
+        })
         : $option_ref->{'diff-cmd'} ? ('--diff-cmd', $option_ref->{'diff-cmd'})
         :                             ()
         ;


### PR DESCRIPTION
Always use:
`--config-option config:working-copy:exclusive-locking-clients=`
with:
`--diff-cmd fcm_graphic_diff`

Close #179.