### PR TITLE
pre/post commit: improve changeset size diagnostic

### DIFF
--- a/sbin/post-commit-bg
+++ b/sbin/post-commit-bg
@@ -100,14 +100,22 @@ main() {
     trac_hook "$REPOS" "$REV" added || RET_CODE=$?
 
     # Check size - send warning email if threshold exceeded
-    local REV_FILE=$REPOS/db/revs/$((REV / 1000))/$REV
-    local REV_FILE_SIZE_THRESHOLD=1048576 # 1MB
-    local REV_FILE_SIZE=$(du -b -s $REV_FILE | cut -f 1)
-    if (($REV_FILE_SIZE > $REV_FILE_SIZE_THRESHOLD)); then
-        echo "REV_FILE_SIZE=$REV_FILE_SIZE # EXCEED $REV_FILE_SIZE_THRESHOLD"
+    local MB=1048576
+    local THRESHOLD=10
+    local SIZE_THRESHOLD_FILE="${REPOS}/hooks/pre-commit-size-threshold.conf"
+    if [[ -f "${SIZE_THRESHOLD_FILE}" && -r "${SIZE_THRESHOLD_FILE}" ]]; then
+        THRESHOLD=$(<"${SIZE_THRESHOLD_FILE}")
+    fi
+    local REV_FILE="${REPOS}/db/revs/$((${REV} / 1000))/${REV}"
+    local REV_FILE_SIZE=$(du -b -s "${REV_FILE}" | cut -f 1)
+    if ((${REV_FILE_SIZE} > ${THRESHOLD} * ${MB})); then
+        echo "REV_FILE_SIZE=${REV_FILE_SIZE} # >${THRESHOLD}MB"
+        RET_CODE=1
+    elif ((${REV_FILE_SIZE} > ${MB})); then
+        echo "REV_FILE_SIZE=${REV_FILE_SIZE} # >1MB <${THRESHOLD}MB"
         RET_CODE=1
     else
-        echo "REV_FILE_SIZE=$REV_FILE_SIZE # within $REV_FILE_SIZE_THRESHOLD"
+        echo "REV_FILE_SIZE=${REV_FILE_SIZE} # <1MB"
     fi
 
     # Install commit.conf and svnperms.conf, if necessary

--- a/sbin/pre-commit
+++ b/sbin/pre-commit
@@ -48,13 +48,16 @@ export PATH=${PATH:-'/usr/local/bin:/bin:/usr/bin'}:$(dirname $0)
 THIS=$(basename $0)
 USER=${USER:-$(whoami)}
 NAME=$(basename "$REPOS")
-LOG_TXN="$REPOS/$THIS-$TXN.log"
+LOG_TXN="$REPOS/log/$THIS-$TXN.log"
 
-main() {
+begin() {
     local NOW=$(date -u +%FT%H:%M:%SZ)
     local AUTHOR=$(svnlook author -t "$TXN" "$REPOS")
     echo "$NOW+ $TXN by $AUTHOR"
     svnlook changed -t "$TXN" "$REPOS"
+}
+
+main() {
     local ADMIN_EMAIL=${FCM_SVN_HOOK_ADMIN_EMAIL:-Admin}
 
     # Check size.
@@ -71,6 +74,10 @@ main() {
         echo "$NAME@$TXN: changeset size ${SIZE}B exceeds ${THRESHOLD}MB." >&2
         echo "Email $ADMIN_EMAIL if you need to bypass this restriction." >&2
         return 1
+    elif ((SIZE > MB)); then
+        # Log any changesets bigger than 1MB
+        SIZE=$(du -h "$TXN_FILE" | cut -f 1)
+        echo "$NAME@$TXN: changeset size ${SIZE}B exceeds 1MB." >&2
     fi
 
     # Check permission.
@@ -97,7 +104,9 @@ main() {
 }
 
 RET_CODE=0
-if ! main 1>"$LOG_TXN" 2>&1; then
+begin 1>"${LOG_TXN}" 2>&1
+LOG_TXN_SIZE="$(stat -c '%s' "${LOG_TXN}")"
+if ! main 1>>"${LOG_TXN}" 2>&1; then
     if [[ -n ${FCM_SVN_HOOK_ADMIN_EMAIL:-} ]]; then
         mail -s "[$THIS] $REPOS@$TXN" "$FCM_SVN_HOOK_ADMIN_EMAIL" <"$LOG_TXN" \
             || true
@@ -105,6 +114,8 @@ if ! main 1>"$LOG_TXN" 2>&1; then
     cat "$LOG_TXN"
     cat "$LOG_TXN" >&2
     RET_CODE=1
+elif [[ "${LOG_TXN_SIZE}" != "$(stat -c '%s' "${LOG_TXN}")" ]]; then
+    cat "$LOG_TXN"
 fi
 rm -f "$LOG_TXN"
 exit $RET_CODE


### PR DESCRIPTION
pre-commit: log (but don't email) >1MB transactions
post-commit: report pre-commit size threshold (normally 10MB) for any >1MB changesets

@benfitzpatrick please review.