### PR TITLE
fcm make: build: fix target select modifier

### DIFF
--- a/doc/user_guide/annex_cfg.html
+++ b/doc/user_guide/annex_cfg.html
@@ -897,20 +897,24 @@ build.ns-incl = foo bar/baz # include items in these name-spaces
 
     <dd>
       <p><dfn>description</dfn>: Selects targets to build according to their
-      keys, categories, name-spaces and tasks.</p>
+      keys, categories and tasks.</p>
 
       <p><dfn>modifier</dfn>: <samp>key</samp> (default if no modifier
-      specified), <samp>category</samp>, <samp>ns</samp> (i.e. name-space) or
-      <samp>task</samp></p>
+      specified), <samp>category</samp> or <samp>task</samp></p>
+
+      <p><dfn>namespace</dfn>: Not allowed if modifier is <samp>key</samp>.
+      Optional if modifier is <samp>category</samp> or <samp>task</samp>. If
+      specified, setting only applies to given name-spaces. Otherwise, setting
+      applies to all name-spaces.</p>
 
       <p><dfn>value</dfn>: A list of space-delimited items (according to the
       modifier).</p>
 
       <p><dfn>example</dfn>:</p>
       <pre>
-build.target{category} = bin lib
-build.target{ns} = egg/fried ham
-build.target{task} = archive install link
+build.target{category}[etc/namelists etc/configs] = etc
+build.target{category}[src/hello src/greet src/world] = bin lib
+build.target{task}[src/public] = archive install
 build.target = egg.sh mince.py
 </pre>
     </dd>

--- a/doc/user_guide/make.html
+++ b/doc/user_guide/make.html
@@ -1742,16 +1742,20 @@ build.prop{fc.flags}[src/food/sausage.f90] = -O4
   you to select targets according to their categories, source name-spaces,
   tasks and keys. The logic is demonstrated by the following example:</p>
   <pre>
-# Selects targets matching these keys
+# Select targets matching these keys
 build.target = egg.bin ham.o bacon.sh
-# OR (
-#     those doing these tasks
+
+# Select all targets doing tasks "install" or "link"
 build.target{task} = install link
-#     AND in these categories
+
+# Select targets in name-space "foo" or "bar" doing tasks "link"
+build.target{task}[foo bar] = link
+
+# Select all targets in the "bin" category
 build.target{category} = bin
-#     AND in these name-spaces
-build.target{ns} = foo bar/baz
-# )
+
+# Select targets in name-space "foo" in the "etc" category
+build.target{category}[foo] = etc
 </pre>
 
   <p>There are times when an automatic target name is not what you want. In
@@ -2193,8 +2197,10 @@ steps = extract preprocess build
 
 # ... some extract configuration
 
+# Switch off preprocessing for all
+preprocess.target{task} =
 # Only preprocess source files in these name-spaces
-preprocess.target{ns} = foo/bar egg/fried.F90
+preprocess.target{task}[foo/bar egg/fried.F90] = process
 # Specifies the macro definitions for the Fortran preprocessor
 preprocess.prop{fpp.defs} = THING=stuff HIGH=tall
 # Specifies the macro definitions for the C preprocessor
@@ -2268,7 +2274,6 @@ preprocess.prop{cpp.defs} = LOWER=lower UNDER LINUX
 preprocess.target =
 preprocess.target{task} = process
 preprocess.target{category} =
-preprocess.target{ns} =
 </pre>
 
   <p>Here is a list of what targets are available for each type of file:</p>

--- a/lib/FCM/System/Make/Preprocess.pm
+++ b/lib/FCM/System/Make/Preprocess.pm
@@ -27,7 +27,11 @@ use FCM::System::Make::Build::FileType::FPP;
 use FCM::System::Make::Build::FileType::H  ;
 
 # Default target selection
-our %TARGET_SELECT_BY = (task => {'process' => 1});
+our %TARGET_SELECT_BY = (
+    'category' => {},
+    'key'      => {},
+    'task'     => {q{} => {'process' => 1}},
+);
 
 # Classes for working with typed source files
 our @FILE_TYPE_UTILS = (

--- a/t/fcm-make/47-build-target-modifier-ns.t
+++ b/t/fcm-make/47-build-target-modifier-ns.t
@@ -1,0 +1,93 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2006-15 Met Office.
+#
+# This file is part of FCM, tools for managing and building source code.
+#
+# FCM is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FCM is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FCM. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test "fcm make", build.target{category} and build.target{task} with namespace.
+#-------------------------------------------------------------------------------
+. "$(dirname "$0")/test_header"
+#-------------------------------------------------------------------------------
+tests 12
+mkdir 'i0'
+cp -r "${TEST_SOURCE_DIR}/${TEST_KEY_BASE}/"* 'i0'
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}"
+run_pass "${TEST_KEY}" fcm make -C 'i0'
+
+grep -F 'build.target{category}' 'i0/.fcm-make/config-on-success.cfg' \
+    >'edited-config-on-success.cfg'
+file_cmp "${TEST_KEY}-edited-config-on-success.cfg" \
+    'edited-config-on-success.cfg' <<'__CFG__'
+build.target{category}[hello] = bin
+__CFG__
+
+find 'i0/build' -type f | sort >'find-i0-build.out'
+file_cmp "${TEST_KEY}-find-i0-build.out" 'find-i0-build.out' <<'__FIND__'
+i0/build/bin/hello
+i0/build/o/hello.o
+__FIND__
+
+"${PWD}/i0/build/bin/hello" <<<'&world_nl /' >'hello.out'
+file_cmp "${TEST_KEY}-hello.out" 'hello.out' <<<'Hello World'
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}-inherit"
+run_pass "${TEST_KEY}" fcm make -C 'i1' \
+    "use=${PWD}/i0" \
+    'build.target{category}[greet] = etc'
+
+grep -F 'build.target{category}' 'i1/.fcm-make/config-on-success.cfg' \
+    >'edited-config-on-success.cfg'
+file_cmp "${TEST_KEY}-edited-config-on-success.cfg" \
+    'edited-config-on-success.cfg' <<'__CFG__'
+build.target{category}[greet] = etc
+build.target{category}[hello] = bin
+__CFG__
+
+find 'i1/build' -type f | sort >'find-i1-build.out'
+file_cmp "${TEST_KEY}-find-i1-build.out" 'find-i1-build.out' <<'__FIND__'
+i1/build/bin/hello
+i1/build/etc/greet/.etc
+i1/build/etc/greet/world.nl
+__FIND__
+
+"${PWD}/i1/build/bin/hello" <'i1/build/etc/greet/world.nl' >'hello.out'
+file_cmp "${TEST_KEY}-hello.out" 'hello.out' <<<'Hello Earth'
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}-inherit-incr"
+touch 'before'
+run_pass "${TEST_KEY}" fcm make -C 'i1' \
+    "use=${PWD}/i0" \
+    'build.target{category}[greet] = bin etc'
+
+grep -F 'build.target{category}' 'i1/.fcm-make/config-on-success.cfg' \
+    >'edited-config-on-success.cfg'
+file_cmp "${TEST_KEY}-edited-config-on-success.cfg" \
+    'edited-config-on-success.cfg' <<'__CFG__'
+build.target{category}[greet] = bin etc
+build.target{category}[hello] = bin
+__CFG__
+
+find 'i1/build' -type f -newer 'before' | sort >'find-i1-build.out'
+file_cmp "${TEST_KEY}-find-i1-build.out" 'find-i1-build.out' <<'__FIND__'
+i1/build/bin/greet
+i1/build/o/greet.o
+__FIND__
+
+"${PWD}/i1/build/bin/greet" <'i1/build/etc/greet/world.nl' >'greet.out'
+file_cmp "${TEST_KEY}-greet.out" 'greet.out' <<<'Greet Earth'
+#-------------------------------------------------------------------------------
+exit 0

--- a/t/fcm-make/47-build-target-modifier-ns/fcm-make.cfg
+++ b/t/fcm-make/47-build-target-modifier-ns/fcm-make.cfg
@@ -1,0 +1,4 @@
+steps=build
+build.source=$HERE/src
+build.prop{file-ext.bin}=
+build.target{category}[hello] = bin

--- a/t/fcm-make/47-build-target-modifier-ns/src/greet/greet.f90
+++ b/t/fcm-make/47-build-target-modifier-ns/src/greet/greet.f90
@@ -1,0 +1,6 @@
+program greet
+character(31) :: world = 'World'
+namelist /world_nl/ world
+read(*, nml=world_nl)
+write(*, '(a,1x,a)') 'Greet', trim(world)
+end program greet

--- a/t/fcm-make/47-build-target-modifier-ns/src/greet/world.nl
+++ b/t/fcm-make/47-build-target-modifier-ns/src/greet/world.nl
@@ -1,0 +1,3 @@
+&world_nl
+world='Earth',
+/

--- a/t/fcm-make/47-build-target-modifier-ns/src/hello/hello.f90
+++ b/t/fcm-make/47-build-target-modifier-ns/src/hello/hello.f90
@@ -1,0 +1,6 @@
+program hello
+character(31) :: world = 'World'
+namelist /world_nl/ world
+read(*, nml=world_nl)
+write(*, '(a,1x,a)') 'Hello', trim(world)
+end program hello

--- a/t/fcm-make/47-build-target-modifier-ns/src/hello/world.nl
+++ b/t/fcm-make/47-build-target-modifier-ns/src/hello/world.nl
@@ -1,0 +1,3 @@
+&world_nl
+world='Jupiter',
+/


### PR DESCRIPTION
The `category` modifier should now work.
The `ns` modifier never worked, and is removed.
Instead `task` and `category` selection can now be filtered by
name space.

Close #194.