### PR TITLE
Allow bob as a synonym of branch-of-branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,7 @@ below:
 * Matt Shin (Met Office, UK)
 * Matt Pryor (Met Office, UK)
 * Roddy Sharp (Met Office, UK)
+* Stuart Whitehouse (Met Office, UK)
 
 (All contributors are identifiable with email addresses in the version
 control logs or otherwise.)

--- a/doc/user_guide/command_ref.html
+++ b/doc/user_guide/command_ref.html
@@ -220,7 +220,7 @@
 
     <dd>
       <dl>
-        <dt><code>--branch-of-branch</code></dt>
+        <dt><code>--branch-of-branch</code>, <code>--bob</code></dt>
 
         <dd>If the source URL is a valid URL of a branch in a standard FCM
         project, this option tells the system to create a branch of the source

--- a/lib/FCM/CLI/Parser.pm
+++ b/lib/FCM/CLI/Parser.pm
@@ -43,7 +43,7 @@ our %OPTION_OF = map {
     [['archive'            ,            ], ['a'], OPT_BOOL],
     [['auto-log'           ,            ], [   ], OPT_BOOL],
     [['branch'             ,            ], ['b'], OPT_BOOL],
-    [['branch-of-branch'   ,            ], [   ], OPT_BOOL],
+    [['branch-of-branch'   , 'bob'      ], [   ], OPT_BOOL],
     [['browser'            ,            ], ['b'], OPT_SCAL],
     [['check'              ,            ], ['c'], OPT_BOOL],
     [['clean'              ,            ], [   ], OPT_BOOL],

--- a/lib/FCM/CLI/fcm-branch-create.pod
+++ b/lib/FCM/CLI/fcm-branch-create.pod
@@ -24,7 +24,7 @@ working copy) must be URL under a standard FCM project.
 
 =over 4
 
-=item --branch-of-branch
+=item --branch-of-branch, --bob
 
 If this option is specified and the SOURCE is a branch, it will create a new
 branch from the SOURCE branch. Otherwise, the branch is created from the trunk.


### PR DESCRIPTION
@matthewrmshin when you get a minute would you mind taking a look at this? Given that people are now creating branches-of-branches fairly often typing --branch-of-branch every time seems a little excessive (do we even need this option now, surely it should be the default if the user runs "fcm branch-create" with a branch as the source?).

I'm also not sure how best to test this, if I just set $FCM_HOME to be my git branch I can't seem to run branch-create at all, any thoughts on what I should be doing to test this? 