### PR TITLE
fcm make: build: more main pattern for C sources

### DIFF
--- a/lib/FCM/System/Make/Build/FileType/C.pm
+++ b/lib/FCM/System/Make/Build/FileType/C.pm
@@ -33,7 +33,7 @@ use File::Basename qw{basename};
 my $RE_FILE = qr{[\w\-+.]+}imsx;
 
 # RE: main program
-my $RE_MAIN = qr{int\s*main\b}msx;
+my $RE_MAIN = qr{\A\s*(?:int|void)?\s*main\b\s*\(?}msx;
 
 my %SOURCE_ANALYSE_DEP_OF = (
     include => sub { $_[0] =~ qr{\A\#\s*include\s+"($RE_FILE)"}msx },

--- a/t/fcm-make/49-build-c-more.t
+++ b/t/fcm-make/49-build-c-more.t
@@ -1,0 +1,50 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2006-15 Met Office.
+#
+# This file is part of FCM, tools for managing and building source code.
+#
+# FCM is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FCM is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FCM. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test build C source file with mixed case name and has main function.
+#-------------------------------------------------------------------------------
+. "$(dirname "$0")/test_header"
+#-------------------------------------------------------------------------------
+tests 8
+cp -r "${TEST_SOURCE_DIR}/${TEST_KEY_BASE}/"* '.'
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}"
+run_pass "${TEST_KEY}" fcm make
+grep '^\[info\] target ' fcm-make.log >"${TEST_KEY}.target.log"
+file_cmp "${TEST_KEY}.target.log" "${TEST_KEY}.target.log" <<'__LOG__'
+[info] target hi
+[info] target  - hi.o
+[info] target hello
+[info] target  - hello.o
+[info] target greet
+[info] target  - greet.o
+__LOG__
+
+"${PWD}/build/bin/greet" >"${TEST_KEY}.greet.out"
+run_pass "${TEST_KEY}.greet.rc" test $? -eq 12
+file_cmp "${TEST_KEY}.greet.out" "${TEST_KEY}.greet.out" <<<'Greet World'
+
+run_pass "${TEST_KEY}.hello" "${PWD}/build/bin/hello"
+file_cmp "${TEST_KEY}.hello.out" "${TEST_KEY}.hello.out" <<<'Hello World'
+
+"${PWD}/build/bin/hi" >"${TEST_KEY}.hi.out"
+run_pass "${TEST_KEY}.hi.rc" test $? -eq 9
+file_cmp "${TEST_KEY}.hi.out" "${TEST_KEY}.hi.out" <<<'Hi World'
+#-------------------------------------------------------------------------------
+exit 0

--- a/t/fcm-make/49-build-c-more/fcm-make.cfg
+++ b/t/fcm-make/49-build-c-more/fcm-make.cfg
@@ -1,0 +1,4 @@
+steps=build
+build.source=$HERE/src
+build.target{task}=link
+build.prop{file-ext.bin}=

--- a/t/fcm-make/49-build-c-more/src/greet.c
+++ b/t/fcm-make/49-build-c-more/src/greet.c
@@ -1,0 +1,4 @@
+#include <stdio.h>
+void main(void) {
+    printf("Greet World\n");
+}

--- a/t/fcm-make/49-build-c-more/src/hello.c
+++ b/t/fcm-make/49-build-c-more/src/hello.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+int main(void) {
+    printf("Hello World\n");
+    return 0;
+}

--- a/t/fcm-make/49-build-c-more/src/hi.c
+++ b/t/fcm-make/49-build-c-more/src/hi.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+void
+main(void) {
+    printf("Hi World\n");
+}


### PR DESCRIPTION
Now recognise `void main(` and just `main(`.` Close #203.