### PR TITLE
fcm make: build: support more prop on target

### DIFF
--- a/doc/user_guide/annex_cfg.html
+++ b/doc/user_guide/annex_cfg.html
@@ -1138,7 +1138,9 @@ build.prop{fc.libs}[myprog.exe] = netcdf grib
 
     <dt id="make.build.prop.dep.f.module">dep.f.module</dt>
 
-    <dd>Specifies a list of manual Fortran module dependencies.</dd>
+    <dd>Specifies a list of manual Fortran module dependencies. Note: This
+    modifier does not work if the name-space is specified using a target
+    name.</dd>
 
     <dt id="make.build.prop.dep.include">dep.include</dt>
 
@@ -1317,7 +1319,8 @@ build.prop{fc.libs}[myprog.exe] = netcdf grib
 
     <dd>Switches off a list of automatic Fortran module dependencies. If the
     value is a <samp>*</samp>, switches off all automatic Fortran module
-    dependencies.</dd>
+    dependencies. Note: This modifier does not work if the name-space is
+    specified using a target name.</dd>
 
     <dt id="make.build.prop.no-dep.include">no-dep.include</dt>
 

--- a/doc/user_guide/make.html
+++ b/doc/user_guide/make.html
@@ -1670,6 +1670,30 @@ build.prop{fc.flags}[sausage.o] = -O4
 build.prop{fc.flags}[src/food/sausage.f90] = -O4
 </pre>
 
+  <p>This works with most property modifiers, even for dependency related
+  modifiers such as <code>no-dep.o</code>. E.g.:</p>
+
+  <pre>
+build.prop{no-dep.include}[sausage.o] = enum.f90
+build.prop{include-paths}[sausage.o] = /path/to/additives
+</pre>
+  
+  <p>However, the following will not work:</p>
+
+  <pre>
+build.prop{no-dep.f.module}[sausage.o] = pork
+</pre>
+
+  <p>This is because an object file target is never dependent on a Fortran
+  module by its name. The following will work, however:</p>
+
+  <pre>
+build.prop{no-dep.include}[sausage.o] = pork.mod
+build.prop{no-dep.o}[sausage.mod] = pork.o
+# would be the same as:
+build.prop{no-dep.f.module}[src/food/sausage.f90] = pork
+</pre>
+
   <h3 id="build.target-source-fortran">Build Targets from Source Files: Fortran
   Specifics</h3>
 

--- a/t/fcm-make/50-build-target-dep.t
+++ b/t/fcm-make/50-build-target-dep.t
@@ -1,0 +1,46 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2006-15 Met Office.
+#
+# This file is part of FCM, tools for managing and building source code.
+#
+# FCM is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FCM is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FCM. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test build.prop{dep.o}[target], etc.
+#-------------------------------------------------------------------------------
+. "$(dirname "$0")/test_header"
+tests 7
+#-------------------------------------------------------------------------------
+cp -r "${TEST_SOURCE_DIR}/${TEST_KEY_BASE}/"* '.'
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}"
+
+run_fail "${TEST_KEY}-1" fcm make
+run_pass "${TEST_KEY}-1-log-grep" \
+    grep -F '[FAIL] ! greet.bin           : update task failed' 'fcm-make.log'
+
+# Explicitly add dependency to target
+run_pass "${TEST_KEY}-2" fcm make 'build.prop{dep.o}[greet.bin]=greet_world.o'
+grep '^\[info\] target ' 'fcm-make.log' >"${TEST_KEY}.target.log"
+file_cmp "${TEST_KEY}-2.target.log" "${TEST_KEY}.target.log" <<'__LOG__'
+[info] target greet.bin
+[info] target  - greet.o
+[info] target  - greet_world.o
+__LOG__
+
+run_pass "${TEST_KEY}.greet" "${PWD}/build/bin/greet.bin"
+file_cmp "${TEST_KEY}.greet.out" "${TEST_KEY}.greet.out" <<<'Greet World'
+file_cmp "${TEST_KEY}.greet.err" "${TEST_KEY}.greet.err" <'/dev/null'
+#-------------------------------------------------------------------------------
+exit 0

--- a/t/fcm-make/50-build-target-dep/fcm-make.cfg
+++ b/t/fcm-make/50-build-target-dep/fcm-make.cfg
@@ -1,0 +1,4 @@
+steps=build
+build.source=$HERE/src
+build.target{task}=link
+build.prop{file-ext.bin}=.bin

--- a/t/fcm-make/50-build-target-dep/src/greet.f90
+++ b/t/fcm-make/50-build-target-dep/src/greet.f90
@@ -1,0 +1,7 @@
+program greet
+interface
+subroutine greet_world()
+end subroutine greet_world
+end interface
+call greet_world()
+end program greet

--- a/t/fcm-make/50-build-target-dep/src/greet_world.f90
+++ b/t/fcm-make/50-build-target-dep/src/greet_world.f90
@@ -1,0 +1,3 @@
+subroutine greet_world()
+write(*, '(a)') 'Greet World'
+end subroutine greet_world

--- a/t/fcm-make/51-build-target-no-dep.t
+++ b/t/fcm-make/51-build-target-no-dep.t
@@ -1,0 +1,59 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2006-15 Met Office.
+#
+# This file is part of FCM, tools for managing and building source code.
+#
+# FCM is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FCM is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FCM. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test build.prop{dep.o}[target], etc.
+#-------------------------------------------------------------------------------
+. "$(dirname "$0")/test_header"
+tests 7
+#-------------------------------------------------------------------------------
+cp -r "${TEST_SOURCE_DIR}/${TEST_KEY_BASE}/"* '.'
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}"
+
+run_fail "${TEST_KEY}-1" fcm make
+sed -n '/bad or missing/p; /required by/p' 'fcm-make.log' >'fcm-make.log.edited'
+file_cmp "${TEST_KEY}-1-log-edited" 'fcm-make.log.edited' <<'__LOG__'
+[FAIL] hello_mod.mod: bad or missing dependency (type=1.include)
+[FAIL]     required by: greet_mod.o
+[FAIL]     required by: greet_mod.mod
+[FAIL]     required by: greet.o
+[FAIL]     required by: greet.bin
+__LOG__
+
+# Remove dependency from target
+mkdir 'hello'
+(cd 'hello'; gfortran -c '../src2/hello_mod.f90')
+(cd 'hello'; ar rs 'libhello.a' 'hello_mod.o' 2>'/dev/null')
+run_pass "${TEST_KEY}-2" fcm make \
+    'build.prop{no-dep.include}[greet_mod.o]=hello_mod.mod' \
+    'build.prop{no-dep.o}[greet_mod.mod]=hello_mod.o'
+grep '^\[info\] target ' 'fcm-make.log' >"${TEST_KEY}.target.log"
+file_cmp "${TEST_KEY}-2.target.log" "${TEST_KEY}.target.log" <<'__LOG__'
+[info] target greet.bin
+[info] target  - greet.o
+[info] target  -  - greet_mod.mod
+[info] target  -  -  - greet_mod.o
+[info] target  - greet_mod.o
+__LOG__
+
+run_pass "${TEST_KEY}.greet" "${PWD}/build/bin/greet.bin"
+file_cmp "${TEST_KEY}.greet.out" "${TEST_KEY}.greet.out" <<<'Greet world!'
+file_cmp "${TEST_KEY}.greet.err" "${TEST_KEY}.greet.err" <'/dev/null'
+#-------------------------------------------------------------------------------
+exit 0

--- a/t/fcm-make/51-build-target-no-dep/fcm-make.cfg
+++ b/t/fcm-make/51-build-target-no-dep/fcm-make.cfg
@@ -1,0 +1,7 @@
+steps=build
+build.source=$HERE/src
+build.target{task}=link
+build.prop{file-ext.bin}=.bin
+build.prop{fc.include-paths} = $HERE/hello
+build.prop{fc.lib-paths} = $HERE/hello
+build.prop{fc.libs} = hello

--- a/t/fcm-make/51-build-target-no-dep/src/greet.f90
+++ b/t/fcm-make/51-build-target-no-dep/src/greet.f90
@@ -1,0 +1,4 @@
+program greet
+use greet_mod, only: greet_world
+call greet_world()
+end program greet

--- a/t/fcm-make/51-build-target-no-dep/src/greet_mod.f90
+++ b/t/fcm-make/51-build-target-no-dep/src/greet_mod.f90
@@ -1,0 +1,3 @@
+module greet_mod
+use hello_mod, only: greet_world
+end module greet_mod

--- a/t/fcm-make/51-build-target-no-dep/src/greet_world.f90
+++ b/t/fcm-make/51-build-target-no-dep/src/greet_world.f90
@@ -1,0 +1,3 @@
+subroutine greet_world()
+write(*, '(a)') 'Greet World'
+end subroutine greet_world

--- a/t/fcm-make/51-build-target-no-dep/src2/hello_mod.f90
+++ b/t/fcm-make/51-build-target-no-dep/src2/hello_mod.f90
@@ -1,0 +1,6 @@
+module hello_mod
+contains
+subroutine greet_world()
+write(*, '(a)') 'Greet world!'
+end subroutine greet_world
+end module hello_mod


### PR DESCRIPTION
Support syntax such as (where `hello.exe` is a target name instead of the namespace of a source):

```cfg
build.prop{dep.o}[hello.exe]=world.o greet.o
```
Close #67.