### PR TITLE
Pass a file handle rather than a path to gunzip to work around problems

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@ below:
 
 * Jim Bolton (Met Office, UK)
 * Andrew Clark (Met Office, UK)
+* Martin Dix (CSIRO, Australia)
 * Ben Fitzpatrick (Met Office, UK)
 * Dave Matthews (Met Office, UK)
 * Stephen Oxley (Met Office, UK)

--- a/lib/FCM/System/Make/Share/Dest.pm
+++ b/lib/FCM/System/Make/Share/Dest.pm
@@ -102,7 +102,9 @@ sub _ctx_load {
     }
     my $old_m_ctx = eval {
         my $handle = IO::File->new_tmpfile();
-        gunzip($path, $handle) || die($!);
+        # Open the file here to work around permission problems with file ACLs
+        my $path_handle = new IO::File $path || die("Cannot open cache file $path\n");
+        gunzip($path_handle, $handle) || die($!);
         $handle->seek(0, 0);
         fd_retrieve($handle);
     };


### PR DESCRIPTION
This fixes #226 in the NCI environment.