### PR TITLE
Remove gedit from editor documentation

### DIFF
--- a/doc/user_guide/getting_started.html
+++ b/doc/user_guide/getting_started.html
@@ -74,7 +74,7 @@
 
         <li>environment variable <var>EDITOR</var></li>
 
-        <li>default to <code>vi</code> (or <code>gedit</code> when running the
+        <li>default to <code>vi</code> (or <code>gvim</code> when running the
         FCM GUI)</li>
       </ol>
 
@@ -87,9 +87,6 @@ export SVN_EDITOR='gvim -f'
 
 # Emacs
 export SVN_EDITOR=emacs
-
-# gedit
-export SVN_EDITOR=gedit
 
 # Kate
 export SVN_EDITOR=kate

--- a/lib/FCM/System/CM/CommitMessage.pm
+++ b/lib/FCM/System/CM/CommitMessage.pm
@@ -44,7 +44,7 @@ our $DELIMITER_INFO
     = '--Change summary (not part of commit message)--'
     . "\n";
 our $EDITOR = 'vi';
-our $GEDITOR = 'gedit';
+our $GEDITOR = 'gvim -f';
 our $SUBVERSION_CONFIG_FILE = catfile((getpwuid($<))[7], qw{.subversion/config});
 
 __PACKAGE__->class({gui => '$', util => '&'},


### PR DESCRIPTION
This removes `gedit` from the editor documentation, as (at our site's version) the command can return before the file is saved and the editor is actually closed.