### PR TITLE
Fix Perl sprintf warning

### DIFF
--- a/lib/FCM/System/Make/Share/Dest.pm
+++ b/lib/FCM/System/Make/Share/Dest.pm
@@ -268,9 +268,13 @@ sub _path {
         ? %{$m_ctx} : ('dest' => $m_ctx, 'name' => q{});
     $ctx{'dest'} ||= q{};
     $ctx{'name'} ||= q{};
+    my $path_of_key = $attrib_ref->{path_of}{$key};
     catfile(
         ($ctx{'dest'} ? $ctx{'dest'} : ()),
-        split(q{/}, sprintf($attrib_ref->{path_of}{$key}, $ctx{'name'})),
+        split(
+            q{/},
+            ($path_of_key ? sprintf($path_of_key, $ctx{'name'}) : $path_of_key),
+        ),
         @paths,
     );
 }


### PR DESCRIPTION
Redundant argument in `sprintf` at `lib/FCM/System/Make/Share/Dest.pm` line 273.

The warning shows up on my Ubuntu 16.04 LTS VM. (The format variable supplied to `sprintf`can sometimes be a null string.)

@benfitzpatrick please review.