### PR TITLE
Integrate with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+# Configuration for running FCM test battery on Travis CI
+# See https://travis-ci.org/ for more info.
+
+---
+language: perl
+
+before_install:
+    - cat >"${HOME}/.bashrc" <<<"export PATH=${PWD}/bin:\$PATH"
+    - source "${HOME}/.bashrc"
+
+install: 
+    - sudo apt-get install -y build-essential gfortran
+    - sudo apt-get install -y libxml-parser-perl libconfig-inifiles-perl
+    # For some reason XML::Parser needs to be installed this way
+    - cpanm 'Config::IniFiles' 'XML::Parser'
+    # Latest Subversion
+    - sudo sh -c 'echo "deb http://opensource.wandisco.com/ubuntu `lsb_release -cs` svn19" >> /etc/apt/sources.list.d/subversion19.list'
+    - sudo wget -q http://opensource.wandisco.com/wandisco-debian.gpg -O- | sudo apt-key add -
+    - sudo apt-get update
+    - sudo apt-get install -y subversion libsvn-perl
+    - sudo apt-get install -y heirloom-mailx
+
+script: 
+    - fcm test-battery -j 5

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # FCM
 
+[![Build Status](https://travis-ci.org/metomi/fcm.svg?branch=master)](https://travis-ci.org/metomi/fcm)
+
 FCM: a modern Fortran build system,
 and wrappers to Subversion for scientific software development
 

--- a/t/fcm-make/00-build-basic.t
+++ b/t/fcm-make/00-build-basic.t
@@ -28,7 +28,7 @@ TEST_KEY="$TEST_KEY_BASE"
 run_pass "$TEST_KEY" fcm make
 find .fcm-make build -type f | sed 's/^\(\.fcm-make\/log\).*$/\1/' \
     | sort >"$TEST_KEY.find"
-file_cmp "$TEST_KEY.find" "$TEST_KEY.find" <<'__OUT__'
+sort >"${TEST_KEY}.find.expected" <<'__OUT__'
 .fcm-make/config-as-parsed.cfg
 .fcm-make/config-on-success.cfg
 .fcm-make/ctx.gz
@@ -38,6 +38,7 @@ build/include/world.mod
 build/o/hello.o
 build/o/world.o
 __OUT__
+file_cmp "$TEST_KEY.find" "$TEST_KEY.find" "${TEST_KEY}.find.expected"
 file_test "$TEST_KEY.log" fcm-make.log
 file_test "$TEST_KEY.fcm-make-as-parsed.cfg" fcm-make-as-parsed.cfg
 file_test "$TEST_KEY.fcm-make-on-success.cfg" fcm-make-on-success.cfg

--- a/t/fcm-make/05-build-c-cxx-basic.t
+++ b/t/fcm-make/05-build-c-cxx-basic.t
@@ -33,7 +33,7 @@ TEST_KEY="$TEST_KEY_BASE"
 run_pass "$TEST_KEY" fcm make
 find .fcm-make build -type f | sed 's/^\(\.fcm-make\/log\).*$/\1/' \
     | sort >"$TEST_KEY.find"
-file_cmp "$TEST_KEY.find" "$TEST_KEY.find" <<'__OUT__'
+sort >"${TEST_KEY}.find.expected" <<'__OUT__'
 .fcm-make/config-as-parsed.cfg
 .fcm-make/config-on-success.cfg
 .fcm-make/ctx.gz
@@ -43,6 +43,7 @@ build/bin/cxxhello
 build/o/chello.o
 build/o/cxxhello.o
 __OUT__
+file_cmp "$TEST_KEY.find" "$TEST_KEY.find" "${TEST_KEY}.find.expected"
 run_pass "$TEST_KEY.chello" $PWD/build/bin/chello
 file_cmp "$TEST_KEY.chello.out" "$TEST_KEY.chello.out" <<<'Hello C'
 run_pass "$TEST_KEY.cxxhello" $PWD/build/bin/cxxhello

--- a/t/fcm-make/12-build-class-prop.t
+++ b/t/fcm-make/12-build-class-prop.t
@@ -28,7 +28,7 @@ PATH=$PWD/bin:$PATH
 TEST_KEY="$TEST_KEY_BASE"
 run_pass "$TEST_KEY" fcm make
 find build* -type f | sort >"$TEST_KEY.find"
-file_cmp "$TEST_KEY.find" "$TEST_KEY.find" <<'__FIND__'
+sort >"${TEST_KEY}.find.expected" <<'__FIND__'
 build/bin/hello.bin
 build/o/hello.o
 build_house/bin/hello_house
@@ -38,6 +38,7 @@ build_office/o/hello_office.o
 build_road/bin/hello_road
 build_road/o/hello_road.o
 __FIND__
+file_cmp "$TEST_KEY.find" "$TEST_KEY.find" "${TEST_KEY}.find.expected"
 sed '/^\[info\] shell(0.*) \(my-fc\|gfortran\)/!d; s/^\[info\] shell(0.*) //' \
     .fcm-make/log >"$TEST_KEY.log"
 file_cmp "$TEST_KEY.log" "$TEST_KEY.log" <<__LOG__

--- a/t/fcm-make/23-build-omp.t
+++ b/t/fcm-make/23-build-omp.t
@@ -28,13 +28,15 @@ yes 1.0 | head -n 100 >"$TEST_KEY_BASE.exe.off.out"
 #-------------------------------------------------------------------------------
 TEST_KEY=$TEST_KEY_BASE-on # fc.flag-omp on in new mode
 run_pass "$TEST_KEY" fcm make
-grep ' !\$' fcm-make.log | sort >"$TEST_KEY.log.deps.expected"
-file_cmp  "$TEST_KEY.log.deps" "$TEST_KEY.log.deps.expected" <<'__LOG__'
+grep ' !\$' fcm-make.log | sort >"$TEST_KEY.log.deps"
+sort >"${TEST_KEY}.log.deps.expected" <<'__LOG__'
 [info]              -> (  include) !$i1.f90
 [info]              -> (  include) !$i2.f90
 [info]              -> ( f.module) !$m1
 [info]              -> ( f.module) !$m2
 __LOG__
+file_cmp "${TEST_KEY}.log.deps" \
+    "${TEST_KEY}.log.deps" "${TEST_KEY}.log.deps.expected"
 run_pass "$TEST_KEY.exe" $PWD/build/bin/p1.exe
 file_cmp "$TEST_KEY.exe.out" "$TEST_KEY_BASE.exe.on.out" "$TEST_KEY.exe.out"
 #-------------------------------------------------------------------------------

--- a/t/fcm-make/41-ctx-name.t
+++ b/t/fcm-make/41-ctx-name.t
@@ -21,6 +21,11 @@
 #-------------------------------------------------------------------------------
 . "$(dirname "$0")/test_header"
 
+file_cmp_sorted() {
+    sort - >"${1}.expected"
+    file_cmp "$1" "${2}" "${1}.expected"
+}
+
 find_fcm_make_files() {
     find . "$@" -type f \
         '(' -path '*/build/*' -o \
@@ -58,7 +63,8 @@ __CFG__
 #-------------------------------------------------------------------------------
 run_pass "${TEST_KEY_BASE}-1" fcm make
 find_fcm_make_files >"${TEST_KEY_BASE}-1.find.new"
-file_cmp "${TEST_KEY_BASE}-1.find.new" "${TEST_KEY_BASE}-1.find.new" <<'__FIND__'
+file_cmp_sorted \
+    "${TEST_KEY_BASE}-1.find.new" "${TEST_KEY_BASE}-1.find.new" <<'__FIND__'
 ./.fcm-make/config-as-parsed.cfg
 ./.fcm-make/config-on-success.cfg
 ./.fcm-make/ctx.gz
@@ -72,7 +78,8 @@ find_fcm_make_files '!' -newer 'marker' >"${TEST_KEY_BASE}-2.find.old"
 file_cmp "${TEST_KEY_BASE}-2.find.old" \
     "${TEST_KEY_BASE}-2.find.old" "${TEST_KEY_BASE}-1.find.new"
 find_fcm_make_files -newer 'marker' >"${TEST_KEY_BASE}-2.find.new"
-file_cmp "${TEST_KEY_BASE}-2.find.new" "${TEST_KEY_BASE}-2.find.new" <<'__FIND__'
+file_cmp_sorted \
+    "${TEST_KEY_BASE}-2.find.new" "${TEST_KEY_BASE}-2.find.new" <<'__FIND__'
 ./.fcm-make2/config-as-parsed.cfg
 ./.fcm-make2/config-on-success.cfg
 ./.fcm-make2/ctx.gz
@@ -86,7 +93,7 @@ touch 'marker'
 sleep 1
 run_pass "${TEST_KEY_BASE}-1-incr" fcm make
 find_fcm_make_files '!' -newer 'marker' >"${TEST_KEY_BASE}-1-incr.find.old"
-file_cmp "${TEST_KEY_BASE}-1-incr.find.old" \
+file_cmp_sorted "${TEST_KEY_BASE}-1-incr.find.old" \
     "${TEST_KEY_BASE}-1-incr.find.old" <<'__FIND__'
 ./.fcm-make2/config-as-parsed.cfg
 ./.fcm-make2/config-on-success.cfg
@@ -98,7 +105,7 @@ file_cmp "${TEST_KEY_BASE}-1-incr.find.old" \
 ./extract/a/a.f90
 __FIND__
 find_fcm_make_files -newer 'marker' >"${TEST_KEY_BASE}-1-incr.find.new"
-file_cmp "${TEST_KEY_BASE}-1-incr.find.new" \
+file_cmp_sorted "${TEST_KEY_BASE}-1-incr.find.new" \
     "${TEST_KEY_BASE}-1-incr.find.new" <<'__FIND__'
 ./.fcm-make/config-as-parsed.cfg
 ./.fcm-make/config-on-success.cfg
@@ -109,7 +116,7 @@ touch 'marker'
 sleep 1
 run_pass "${TEST_KEY_BASE}-2-incr" fcm make --name=2
 find_fcm_make_files '!' -newer 'marker' >"${TEST_KEY_BASE}-2-incr.find.old"
-file_cmp "${TEST_KEY_BASE}-2-incr.find.old" \
+file_cmp_sorted "${TEST_KEY_BASE}-2-incr.find.old" \
     "${TEST_KEY_BASE}-2-incr.find.old" <<'__FIND__'
 ./.fcm-make/config-as-parsed.cfg
 ./.fcm-make/config-on-success.cfg
@@ -121,7 +128,7 @@ file_cmp "${TEST_KEY_BASE}-2-incr.find.old" \
 ./extract/a/a.f90
 __FIND__
 find_fcm_make_files -newer 'marker' >"${TEST_KEY_BASE}-2-incr.find.new"
-file_cmp "${TEST_KEY_BASE}-2-incr.find.new" \
+file_cmp_sorted "${TEST_KEY_BASE}-2-incr.find.new" \
     "${TEST_KEY_BASE}-2-incr.find.new" <<'__FIND__'
 ./.fcm-make2/config-as-parsed.cfg
 ./.fcm-make2/config-on-success.cfg
@@ -132,7 +139,7 @@ touch 'marker'
 sleep 1
 run_pass "${TEST_KEY_BASE}-1-new" fcm make --new
 find_fcm_make_files '!' -newer 'marker' >"${TEST_KEY_BASE}-1-new.find.old"
-file_cmp "${TEST_KEY_BASE}-1-new.find.old" \
+file_cmp_sorted "${TEST_KEY_BASE}-1-new.find.old" \
     "${TEST_KEY_BASE}-1-new.find.old" <<'__FIND__'
 ./.fcm-make2/config-as-parsed.cfg
 ./.fcm-make2/config-on-success.cfg
@@ -143,7 +150,7 @@ file_cmp "${TEST_KEY_BASE}-1-new.find.old" \
 ./build/o/b.o
 __FIND__
 find_fcm_make_files -newer 'marker' >"${TEST_KEY_BASE}-1-new.find.new"
-file_cmp "${TEST_KEY_BASE}-1-new.find.new" \
+file_cmp_sorted "${TEST_KEY_BASE}-1-new.find.new" \
     "${TEST_KEY_BASE}-1-new.find.new" <<'__FIND__'
 ./.fcm-make/config-as-parsed.cfg
 ./.fcm-make/config-on-success.cfg
@@ -155,7 +162,7 @@ touch 'marker'
 sleep 1
 run_pass "${TEST_KEY_BASE}-2-new" fcm make --name=2 --new
 find_fcm_make_files '!' -newer 'marker' >"${TEST_KEY_BASE}-2-new.find.old"
-file_cmp "${TEST_KEY_BASE}-2-new.find.old" \
+file_cmp_sorted "${TEST_KEY_BASE}-2-new.find.old" \
     "${TEST_KEY_BASE}-2-new.find.old" <<'__FIND__'
 ./.fcm-make/config-as-parsed.cfg
 ./.fcm-make/config-on-success.cfg
@@ -163,7 +170,7 @@ file_cmp "${TEST_KEY_BASE}-2-new.find.old" \
 ./extract/a/a.f90
 __FIND__
 find_fcm_make_files -newer 'marker' >"${TEST_KEY_BASE}-2-new.find.new"
-file_cmp "${TEST_KEY_BASE}-2-new.find.new" \
+file_cmp_sorted "${TEST_KEY_BASE}-2-new.find.new" \
     "${TEST_KEY_BASE}-2-new.find.new" <<'__FIND__'
 ./.fcm-make2/config-as-parsed.cfg
 ./.fcm-make2/config-on-success.cfg

--- a/t/fcm-make/42-make-mirror-make2.t
+++ b/t/fcm-make/42-make-mirror-make2.t
@@ -21,6 +21,11 @@
 #-------------------------------------------------------------------------------
 . "$(dirname "$0")/test_header"
 
+file_cmp_sorted() {
+    sort - >"${1}.expected"
+    file_cmp "$1" "${2}" "${1}.expected"
+}
+
 find_fcm_make_files() {
     find . "$@" -type f \
         '(' -path '*/build/*' -o \
@@ -52,7 +57,8 @@ __CFG__
 #-------------------------------------------------------------------------------
 run_pass "${TEST_KEY_BASE}-1" fcm make
 find_fcm_make_files >"${TEST_KEY_BASE}-1.find.new"
-file_cmp "${TEST_KEY_BASE}-1.find.new" "${TEST_KEY_BASE}-1.find.new" <<'__FIND__'
+file_cmp_sorted \
+    "${TEST_KEY_BASE}-1.find.new" "${TEST_KEY_BASE}-1.find.new" <<'__FIND__'
 ./.fcm-make/config-as-parsed.cfg
 ./.fcm-make/config-on-success.cfg
 ./.fcm-make/ctx.gz
@@ -68,7 +74,8 @@ find_fcm_make_files '!' -newer 'marker' >"${TEST_KEY_BASE}-2.find.old"
 file_cmp "${TEST_KEY_BASE}-2.find.old" \
     "${TEST_KEY_BASE}-2.find.old" "${TEST_KEY_BASE}-1.find.new"
 find_fcm_make_files -newer 'marker' >"${TEST_KEY_BASE}-2.find.new"
-file_cmp "${TEST_KEY_BASE}-2.find.new" "${TEST_KEY_BASE}-2.find.new" <<'__FIND__'
+file_cmp_sorted \
+    "${TEST_KEY_BASE}-2.find.new" "${TEST_KEY_BASE}-2.find.new" <<'__FIND__'
 ./.fcm-make2/config-as-parsed.cfg
 ./.fcm-make2/config-on-success.cfg
 ./.fcm-make2/ctx.gz
@@ -80,7 +87,7 @@ touch 'marker'
 sleep 1
 run_pass "${TEST_KEY_BASE}-1-incr" fcm make
 find_fcm_make_files '!' -newer 'marker' >"${TEST_KEY_BASE}-1-incr.find.old"
-file_cmp "${TEST_KEY_BASE}-1-incr.find.old" \
+file_cmp_sorted "${TEST_KEY_BASE}-1-incr.find.old" \
     "${TEST_KEY_BASE}-1-incr.find.old" <<'__FIND__'
 ./.fcm-make2/config-as-parsed.cfg
 ./.fcm-make2/config-on-success.cfg
@@ -90,7 +97,7 @@ file_cmp "${TEST_KEY_BASE}-1-incr.find.old" \
 ./extract/hello/hello.f90
 __FIND__
 find_fcm_make_files -newer 'marker' >"${TEST_KEY_BASE}-1-incr.find.new"
-file_cmp "${TEST_KEY_BASE}-1-incr.find.new" \
+file_cmp_sorted "${TEST_KEY_BASE}-1-incr.find.new" \
     "${TEST_KEY_BASE}-1-incr.find.new" <<'__FIND__'
 ./.fcm-make/config-as-parsed.cfg
 ./.fcm-make/config-on-success.cfg
@@ -103,7 +110,7 @@ touch 'marker'
 sleep 1
 run_pass "${TEST_KEY_BASE}-2-incr" fcm make -f fcm-make2.cfg
 find_fcm_make_files '!' -newer 'marker' >"${TEST_KEY_BASE}-2-incr.find.old"
-file_cmp "${TEST_KEY_BASE}-2-incr.find.old" \
+file_cmp_sorted "${TEST_KEY_BASE}-2-incr.find.old" \
     "${TEST_KEY_BASE}-2-incr.find.old" <<'__FIND__'
 ./.fcm-make/config-as-parsed.cfg
 ./.fcm-make/config-on-success.cfg
@@ -115,7 +122,7 @@ file_cmp "${TEST_KEY_BASE}-2-incr.find.old" \
 ./mirror/fcm-make2.cfg.orig
 __FIND__
 find_fcm_make_files -newer 'marker' >"${TEST_KEY_BASE}-2-incr.find.new"
-file_cmp "${TEST_KEY_BASE}-2-incr.find.new" \
+file_cmp_sorted "${TEST_KEY_BASE}-2-incr.find.new" \
     "${TEST_KEY_BASE}-2-incr.find.new" <<'__FIND__'
 ./.fcm-make2/config-as-parsed.cfg
 ./.fcm-make2/config-on-success.cfg

--- a/t/fcm-make/43-ctx-name-inherit.t
+++ b/t/fcm-make/43-ctx-name-inherit.t
@@ -21,6 +21,11 @@
 #-------------------------------------------------------------------------------
 . "$(dirname "$0")/test_header"
 
+file_cmp_sorted() {
+    sort - >"${1}.expected"
+    file_cmp "$1" "${2}" "${1}.expected"
+}
+
 find_fcm_make_files() {
     find . "$@" -type f \
         '(' -path '*/build/*' -o \
@@ -70,7 +75,8 @@ __FORTRAN__
 
 run_pass "${TEST_KEY_BASE}-greet" fcm make -C "${PWD}/greet" -n '-friend'
 (cd 'greet' && find_fcm_make_files) >"${TEST_KEY_BASE}-greet.find"
-file_cmp "${TEST_KEY_BASE}-greet.find" "${TEST_KEY_BASE}-greet.find" <<'__FIND__'
+file_cmp_sorted \
+    "${TEST_KEY_BASE}-greet.find" "${TEST_KEY_BASE}-greet.find" <<'__FIND__'
 ./.fcm-make-friend/config-as-parsed.cfg
 ./.fcm-make-friend/config-on-success.cfg
 ./.fcm-make-friend/ctx.gz

--- a/t/fcm-make/44-ctx-name-inherit-compat.t
+++ b/t/fcm-make/44-ctx-name-inherit-compat.t
@@ -21,6 +21,11 @@
 #-------------------------------------------------------------------------------
 . "$(dirname "$0")/test_header"
 
+file_cmp_sorted() {
+    sort - >"${1}.expected"
+    file_cmp "$1" "${2}" "${1}.expected"
+}
+
 find_fcm_make_files() {
     find . "$@" -type f \
         '(' -path '*/build/*' -o \
@@ -80,7 +85,7 @@ __FORTRAN__
 
 run_pass "${TEST_KEY_BASE}" fcm make -C "${PWD}/greet" -n '-friend'
 (cd 'greet' && find_fcm_make_files) >"${TEST_KEY_BASE}.find"
-file_cmp "${TEST_KEY_BASE}.find" "${TEST_KEY_BASE}.find" <<'__FIND__'
+file_cmp_sorted "${TEST_KEY_BASE}.find" "${TEST_KEY_BASE}.find" <<'__FIND__'
 ./.fcm-make-friend/config-as-parsed.cfg
 ./.fcm-make-friend/config-on-success.cfg
 ./.fcm-make-friend/ctx.gz

--- a/t/fcm-make/46-archive-mode.t
+++ b/t/fcm-make/46-archive-mode.t
@@ -20,6 +20,12 @@
 # Tests for "fcm make --archive"
 #-------------------------------------------------------------------------------
 . "$(dirname "$0")/test_header"
+
+file_cmp_sorted() {
+    sort - >"${1}.expected"
+    file_cmp "$1" "${2}" "${1}.expected"
+}
+
 tests 11
 #-------------------------------------------------------------------------------
 # Create a repository to extract
@@ -52,7 +58,7 @@ __CFG__
 TEST_KEY="${TEST_KEY_BASE}-on-new"
 run_pass "${TEST_KEY}" fcm make -a
 find '.fcm-make/cache' 'build' -type f | sort >"${TEST_KEY}.find"
-file_cmp "${TEST_KEY}.find" "${TEST_KEY}.find" <<'__FIND__'
+file_cmp_sorted "${TEST_KEY}.find" "${TEST_KEY}.find" <<'__FIND__'
 .fcm-make/cache/extract.tar.gz
 build/bin/hello
 build/include.tar.gz
@@ -66,14 +72,14 @@ TEST_KEY="${TEST_KEY_BASE}-on-incr"
 run_pass "${TEST_KEY}" fcm make -a
 find '.fcm-make/cache' 'build' -type f -newer 'new' \
     | sort >"${TEST_KEY}.find.new"
-file_cmp "${TEST_KEY}.find.new" "${TEST_KEY}.find.new" <<'__FIND__'
+file_cmp_sorted "${TEST_KEY}.find.new" "${TEST_KEY}.find.new" <<'__FIND__'
 .fcm-make/cache/extract.tar.gz
 build/include.tar.gz
 build/o.tar.gz
 __FIND__
 find '.fcm-make/cache' 'build' -type f '!' -newer 'new' \
     | sort >"${TEST_KEY}.find.old"
-file_cmp "${TEST_KEY}.find.old" "${TEST_KEY}.find.old" <<'__FIND__'
+file_cmp_sorted "${TEST_KEY}.find.old" "${TEST_KEY}.find.old" <<'__FIND__'
 build/bin/hello
 __FIND__
 
@@ -82,13 +88,13 @@ run_pass "${TEST_KEY}" \
     fcm make -a 'build.prop{archive-ok-target-category}=o'
 find '.fcm-make/cache' 'build' -type f -newer 'new' \
     | sort >"${TEST_KEY}.find.new"
-file_cmp "${TEST_KEY}.find.new" "${TEST_KEY}.find.new" <<'__FIND__'
+file_cmp_sorted "${TEST_KEY}.find.new" "${TEST_KEY}.find.new" <<'__FIND__'
 .fcm-make/cache/extract.tar.gz
 build/o.tar.gz
 __FIND__
 find '.fcm-make/cache' 'build' -type f '!' -newer 'new' \
     | sort >"${TEST_KEY}.find.old"
-file_cmp "${TEST_KEY}.find.old" "${TEST_KEY}.find.old" <<'__FIND__'
+file_cmp_sorted "${TEST_KEY}.find.old" "${TEST_KEY}.find.old" <<'__FIND__'
 build/bin/hello
 build/include/world_mod.mod
 __FIND__
@@ -96,10 +102,10 @@ __FIND__
 run_pass "${TEST_KEY_BASE}-off" fcm make
 find '.fcm-make/cache' 'build' -type f -newer 'new' \
     | sort >"${TEST_KEY}.find.new"
-file_cmp "${TEST_KEY}.find.new" "${TEST_KEY}.find.new" <'/dev/null'
+file_cmp_sorted "${TEST_KEY}.find.new" "${TEST_KEY}.find.new" <'/dev/null'
 find '.fcm-make/cache' 'build' -type f '!' -newer 'new' \
     | sort >"${TEST_KEY}.find.old"
-file_cmp "${TEST_KEY}.find.old" "${TEST_KEY}.find.old" <<'__FIND__'
+file_cmp_sorted "${TEST_KEY}.find.old" "${TEST_KEY}.find.old" <<'__FIND__'
 .fcm-make/cache/extract/hello/0/hello.f90
 .fcm-make/cache/extract/hello/0/world_mod.f90
 build/bin/hello

--- a/t/svn-hooks/03-post-commit-bg.t
+++ b/t/svn-hooks/03-post-commit-bg.t
@@ -427,6 +427,7 @@ svn co -q "${REPOS_URL}/hello/trunk" 'hello'
 echo 'Hello' >'hello/file'
 svn ci -q -m 'hello whatever' '--no-auth-cache' '--username=root' 'hello'
 poll 10 grep -q '^RET_CODE=' "${REPOS_PATH}/log/post-commit.log"
+poll 10 test -e 'mail.out'
 REV="$(<rev)"
 file_grep "${TEST_KEY}.mail.out.1" \
     "^-rnotifications@localhost -sfoo@${REV} by root" 'mail.out'


### PR DESCRIPTION
Run `fcm test-battery` on Travis CI. For some reason, the sort order on the Travis CI box is very different. I have also added some extra polling to ensure the stability of  `t/svn-hooks/03-post-commit-bg.t`.