### PR TITLE
fcm-add-trac-env: add `owner` permission

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,17 @@ before_install:
 install: 
     - sudo apt-get install -y build-essential gfortran
     - sudo apt-get install -y libxml-parser-perl libconfig-inifiles-perl
+    - sudo apt-get install -y libdbi-perl libdbd-sqlite3-perl
     # For some reason XML::Parser needs to be installed this way
     - cpanm 'Config::IniFiles' 'XML::Parser'
     # Latest Subversion
     - sudo sh -c 'echo "deb http://opensource.wandisco.com/ubuntu `lsb_release -cs` svn19" >> /etc/apt/sources.list.d/subversion19.list'
     - sudo wget -q http://opensource.wandisco.com/wandisco-debian.gpg -O- | sudo apt-key add -
     - sudo apt-get update
-    - sudo apt-get install -y subversion libsvn-perl
+    - sudo apt-get install -y subversion libsvn-perl python-subversion
     - sudo apt-get install -y heirloom-mailx
+    - sudo apt-get install -y python-pip
+    - sudo pip install trac
 
 script: 
     - fcm test-battery -j 5

--- a/lib/FCM/Admin/System.pm
+++ b/lib/FCM/Admin/System.pm
@@ -140,6 +140,11 @@ sub add_trac_environment {
         my @command = (q{trac-admin}, $project->get_trac_live_path(), @args);
         $RUN->($log, sub {!system(@command)});
     };
+    my $TRAC_ADMIN_CONT = sub {
+        my ($log, @args) = @_;
+        my @command = (q{trac-admin}, $project->get_trac_live_path(), @args);
+        $RUNNER->run_continue($log, sub {!system(@command)});
+    };
     $TRAC_ADMIN->(
         "initialising Trac environment",
         q{initenv},
@@ -152,18 +157,22 @@ sub add_trac_environment {
     if ($group) {
         _chgrp_and_chmod($project->get_trac_live_path(), $group);
     }
+    # Note: For some reason, the commands to remove example components,
+    # versions, milestones, priorities fail using the "pip install trac" version
+    # on Travis CI. It is safe to allow the logic to continue after a failure
+    # here as they are really unimportant and can easily be configured later.
     for my $item (qw{component1 component2}) {
-        $TRAC_ADMIN->(
+        $TRAC_ADMIN_CONT->(
             "removing example component $item", q{component remove}, $item,
         );
     }
     for my $item (qw{1.0 2.0}) {
-        $TRAC_ADMIN->(
+        $TRAC_ADMIN_CONT->(
             "removing example version $item", q{version remove}, $item,
         );
     }
     for my $item (qw{milestone1 milestone2 milestone3 milestone4}) {
-        $TRAC_ADMIN->(
+        $TRAC_ADMIN_CONT->(
             "removing example milestone $item", q{milestone remove}, $item,
         );
     }
@@ -173,12 +182,15 @@ sub add_trac_environment {
         ['blocker'  => 'critical'],
     ) {
         my ($old, $new) = @{$item};
-        $TRAC_ADMIN->(
+        $TRAC_ADMIN_CONT->(
             "changing priority $old to $new", qw{priority change}, $old, $new,
         );
     }
     $TRAC_ADMIN->(
         "adding admin permission", qw{permission add admin TRAC_ADMIN},
+    );
+    $TRAC_ADMIN->(
+        "adding admin permission", qw{permission add owner TRAC_ADMIN},
     );
     my @admin_users = shellwords($CONFIG->get_trac_admin_users());
     for my $item (@admin_users) {

--- a/t/fcm-add-trac-env/00-basic.t
+++ b/t/fcm-add-trac-env/00-basic.t
@@ -24,14 +24,14 @@
 if ! which trac-admin 1>/dev/null 2>/dev/null; then
     skip_all 'trac-admin not available'
 fi
-tests 20
+tests 28
 #-------------------------------------------------------------------------------
 set -e
 mkdir -p etc srv/{svn,trac}
 # Configuration
 export FCM_CONF_PATH="$PWD/etc"
 ADMIN_USERS='holly ivy'
-cat >etc/admin.cfg <<__CONF__
+cat >'etc/admin.cfg' <<__CONF__
 svn_live_dir=$PWD/srv/svn
 trac_admin_users=$ADMIN_USERS
 trac_live_dir=$PWD/srv/trac
@@ -49,12 +49,16 @@ for NAME in bus car lorry taxi; do
     # Trac environment directory exists
     run_pass "$TEST_KEY-d" test -d "$PWD/srv/trac/$NAME"
     # Admin users are set
+    trac-admin "$PWD/srv/trac/$NAME" 'permission' 'export' "$TEST_KEY-d-perms"
+    # For some reason, the "echo" for the next test is lost in the ether unless
+    # we have an "echo" here.
+    echo
     for ADMIN_USER in $ADMIN_USERS; do
-        trac-admin "$PWD/srv/trac/$NAME" permission list "$ADMIN_USER" \
-            >"$TEST_KEY.perm.out"
-        file_grep "$TEST_KEY.perm.out" \
-            "$ADMIN_USER  *TRAC_ADMIN" "$TEST_KEY.perm.out"
+        file_grep "$TEST_KEY-d-perms-$ADMIN_USER" \
+            "$ADMIN_USER,admin" "$TEST_KEY-d-perms"
     done
+    file_grep "$TEST_KEY-d-perms-owner" "owner,TRAC_ADMIN" "$TEST_KEY-d-perms"
+    file_grep "$TEST_KEY-d-perms-admin" "admin,TRAC_ADMIN" "$TEST_KEY-d-perms"
     # Subversion repository paths in place
     if [[ -d "srv/svn/$NAME" ]]; then
         file_grep "$TEST_KEY-repository_dir" \

--- a/t/svn-hooks/03-post-commit-bg.t
+++ b/t/svn-hooks/03-post-commit-bg.t
@@ -228,6 +228,7 @@ perl -e 'map {print(rand())} 1..2097152' >'file3' # compress should be >10MB
 svn import --no-auth-cache -q -m"${TEST_KEY}" 'file3' "${REPOS_URL}/file3"
 REV="$(<'rev')"
 poll 10 grep -q '^RET_CODE=' "${REPOS_PATH}/log/post-commit.log"
+poll 10 test -e 'mail.out'
 date2datefmt "${REPOS_PATH}/log/post-commit.log" \
     | sed '/^trac-admin/d; s/^\(REV_FILE_SIZE=\).*\( #\)/\1???\2/' \
     >"${TEST_KEY}.log"


### PR DESCRIPTION
Both `admin` and `owner` are set up to have `TRAC_ADMIN` permissions,
but this allows us to distinguish between the admin team who set up
hosting of the Trac environments and the owners of the software
projects.

Install Trac on Travis CI build, so we can have CI for Trac related functionality.

@benfitzpatrick please review.