### PR TITLE
Fix fcm make: build.prop{ignore-missing-dep-ns}

### DIFF
--- a/lib/FCM/System/Make/Build.pm
+++ b/lib/FCM/System/Make/Build.pm
@@ -1300,14 +1300,15 @@ sub _targets_select {
     if (keys(%dup_in)) {
         return $E->throw($E->BUILD_TARGET_DUP, \%dup_in);
     }
-    my @ignore_missing_dep_ns_list
-        = _props($attrib_ref, 'ignore-missing-dep-ns', $ctx);
+    my @ignore_missing_dep_ns_list = map {$_ eq q{/} ? q{} : $_} (
+        _props($attrib_ref, 'ignore-missing-dep-ns', $ctx)
+    );
     KEY:
     for my $key (sort(keys(%missing_deps_in))) {
         my $target = $target_of{$key};
         for my $ns (@ignore_missing_dep_ns_list) {
             if ($UTIL->ns_common($ns, $target->get_ns()) eq $ns) { # target in ns
-                my $hash_ref = @{delete($missing_deps_in{$key})};
+                my $hash_ref = delete($missing_deps_in{$key});
                 my @deps = @{$hash_ref->{"values"}};
                 for my $dep (@deps) {
                     $EVENT->(

--- a/t/fcm-make/54-build-ignore-missing-dep-ns.t
+++ b/t/fcm-make/54-build-ignore-missing-dep-ns.t
@@ -1,0 +1,60 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2006-16 Met Office.
+#
+# This file is part of FCM, tools for managing and building source code.
+#
+# FCM is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FCM is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FCM. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test build.prop{ignore-missing-dep-ns}
+#-------------------------------------------------------------------------------
+. "$(dirname "$0")/test_header"
+tests 7
+#-------------------------------------------------------------------------------
+cp -r "${TEST_SOURCE_DIR}/${TEST_KEY_BASE}/"* '.'
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}"
+
+run_fail "${TEST_KEY}-1" fcm make
+sed -n '/bad or missing/p; /required by/p' 'fcm-make.log' >'fcm-make.log.edited'
+file_cmp "${TEST_KEY}-1-log-edited" 'fcm-make.log.edited' <<'__LOG__'
+[FAIL] hello_mod.mod: bad or missing dependency (type=1.include)
+[FAIL]     required by: greet_mod.o
+[FAIL]     required by: greet_mod.mod
+[FAIL]     required by: greet.o
+[FAIL]     required by: greet.bin
+__LOG__
+
+# Remove dependency from target
+mkdir 'hello'
+(cd 'hello'; gfortran -c '../src2/hello_mod.f90')
+(cd 'hello'; ar rs 'libhello.a' 'hello_mod.o' 2>'/dev/null')
+run_pass "${TEST_KEY}-2" fcm make \
+    'build.prop{ignore-missing-dep-ns}=/'
+sed -n '/^\[info\] target /p; /ignore-missing-dep:/p' 'fcm-make.log' \
+    >"${TEST_KEY}.target.log"
+file_cmp "${TEST_KEY}-2.target.log" "${TEST_KEY}.target.log" <<'__LOG__'
+[WARN] greet_mod.o                   : ignore-missing-dep: (  include) hello_mod.mod
+[info] target greet.bin
+[info] target  - greet.o
+[info] target  -  - greet_mod.mod
+[info] target  -  -  - greet_mod.o
+[info] target  - greet_mod.o
+__LOG__
+
+run_pass "${TEST_KEY}.greet" "${PWD}/build/bin/greet.bin"
+file_cmp "${TEST_KEY}.greet.out" "${TEST_KEY}.greet.out" <<<'Greet world!'
+file_cmp "${TEST_KEY}.greet.err" "${TEST_KEY}.greet.err" <'/dev/null'
+#-------------------------------------------------------------------------------
+exit 0

--- a/t/fcm-make/54-build-ignore-missing-dep-ns/fcm-make.cfg
+++ b/t/fcm-make/54-build-ignore-missing-dep-ns/fcm-make.cfg
@@ -1,0 +1,7 @@
+steps=build
+build.source=$HERE/src
+build.target{task}=link
+build.prop{file-ext.bin}=.bin
+build.prop{fc.include-paths} = $HERE/hello
+build.prop{fc.lib-paths} = $HERE/hello
+build.prop{fc.libs} = hello

--- a/t/fcm-make/54-build-ignore-missing-dep-ns/src/greet.f90
+++ b/t/fcm-make/54-build-ignore-missing-dep-ns/src/greet.f90
@@ -1,0 +1,4 @@
+program greet
+use greet_mod, only: greet_world
+call greet_world()
+end program greet

--- a/t/fcm-make/54-build-ignore-missing-dep-ns/src/greet_mod.f90
+++ b/t/fcm-make/54-build-ignore-missing-dep-ns/src/greet_mod.f90
@@ -1,0 +1,3 @@
+module greet_mod
+use hello_mod, only: greet_world
+end module greet_mod

--- a/t/fcm-make/54-build-ignore-missing-dep-ns/src/greet_world.f90
+++ b/t/fcm-make/54-build-ignore-missing-dep-ns/src/greet_world.f90
@@ -1,0 +1,3 @@
+subroutine greet_world()
+write(*, '(a)') 'Greet World'
+end subroutine greet_world

--- a/t/fcm-make/54-build-ignore-missing-dep-ns/src2/hello_mod.f90
+++ b/t/fcm-make/54-build-ignore-missing-dep-ns/src2/hello_mod.f90
@@ -1,0 +1,6 @@
+module hello_mod
+contains
+subroutine greet_world()
+write(*, '(a)') 'Greet world!'
+end subroutine greet_world
+end module hello_mod


### PR DESCRIPTION
Logic was incorrect and untested.

The old logic would fail like this:
```
[FAIL] Not an ARRAY reference at /opt/fcm/bin/../lib/FCM/System/Make/Build.pm line 1310.
```

Bug reported by @gdcarver via email.