### PR TITLE
branch-delete: fix Perl warning on rosie branches

### DIFF
--- a/lib/FCM1/CmBranch.pm
+++ b/lib/FCM1/CmBranch.pm
@@ -675,14 +675,14 @@ sub del {
 
   # Create a temporary file for the commit log message
   my $temp_handle = $self->_commit_message(
-      sprintf("Deleted %s.\n", $self->branch_path()), 'D', $non_interactive,
+    sprintf("Deleted %s.\n", $self->branch_path()), 'D', $non_interactive,
   );
 
   # Check with the user to see if he/she wants to go ahead
   # ----------------------------------------------------------------------------
-  if (not $non_interactive) {
+  if (!$non_interactive) {
     my $mesg = '';
-    if (!$self->layout()->is_owned_by_user()) {
+    if ($self->branch_owner() && !$self->layout()->is_owned_by_user()) {
       $mesg .= "\n";
 
       if (exists $FCM1::CmUrl::owner_keywords{$self->branch_owner()}) {

--- a/lib/FCM1/CmUrl.pm
+++ b/lib/FCM1/CmUrl.pm
@@ -246,20 +246,26 @@ sub svnlog {
 
   # Check whether a "svn log" run is necessary
   # ----------------------------------------------------------------------------
-  my $need_update = ! ($revs [0] == $revs [1] and exists $self->{LOG}{$revs [0]});
-  my @ranges      = @revs;
-  if ($need_update and $self->{LOG_RANGE}) {
-    my %log_range = %{ $self->{LOG_RANGE} };
+  my $need_update = !($revs[0] == $revs[1] && exists($self->{LOG}{$revs [0]}));
+  my @ranges = @revs;
+  if ($need_update && $self->{LOG_RANGE}) {
+    my %log_range = %{$self->{LOG_RANGE}};
+    $log_range{LOWER_SOC} ||= 0;
+    $log_range{LOWER} ||= 0;
 
-    if ($stop_on_copy) {
-      $ranges [1] = $log_range{UPPER} if $ranges [1] >= $log_range{LOWER_SOC};
-
-    } else {
-      $ranges [1] = $log_range{UPPER} if $ranges [1] >= $log_range{LOWER};
+    if ($stop_on_copy && $ranges[1] >= $log_range{LOWER_SOC}) {
+      if ($ranges[1] >= $log_range{LOWER_SOC}) {
+        $ranges[1] = $log_range{UPPER};
+      }
+    }
+    else {
+      if ($ranges[1] >= $log_range{LOWER}) {
+        $ranges[1] = $log_range{UPPER};
+      }
     }
   }
 
-  $need_update = 0 if $ranges [0] < $ranges [1];
+  $need_update = 0 if $ranges[0] < $ranges[1];
 
   if ($need_update) {
     my @entries = @{$SVN->get_log(

--- a/t/fcm-add-trac-env/00-basic.t
+++ b/t/fcm-add-trac-env/00-basic.t
@@ -62,7 +62,7 @@ for NAME in bus car lorry taxi; do
     # Subversion repository paths in place
     if [[ -d "srv/svn/$NAME" ]]; then
         file_grep "$TEST_KEY-repository_dir" \
-            "repository_dir=$PWD/srv/svn/$NAME" \
+            "dir=$PWD/srv/svn/$NAME" \
             "$PWD/srv/trac/$NAME/conf/trac.ini"
     fi
 done

--- a/t/fcm-branch-delete/02-rosie.t
+++ b/t/fcm-branch-delete/02-rosie.t
@@ -1,0 +1,39 @@
+#!/bin/bash
+# ------------------------------------------------------------------------------
+# (C) British Crown Copyright 2006-16 Met Office.
+#
+# This file is part of FCM, tools for managing and building source code.
+#
+# FCM is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FCM is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FCM. If not, see <http://www.gnu.org/licenses/>.
+# ------------------------------------------------------------------------------
+# Test "fcm branch-delete" does not produce warnings for rosie branches.
+#-------------------------------------------------------------------------------
+. "$(dirname "$0")/test_header"
+tests 3
+#-------------------------------------------------------------------------------
+# Tests fcm branch-delete with bad argument, and in a working copy
+TEST_KEY="${TEST_KEY_BASE}"
+setup
+init_repos_layout_roses
+svn copy -q -m 'create a branch' \
+    "${REPOS_URL}/a/a/0/0/0/trunk" "${REPOS_URL}/a/a/0/0/0/my-branch"
+run_pass "${TEST_KEY}" \
+    fcm branch-delete --non-interactive "${REPOS_URL}/a/a/0/0/0/my-branch"
+file_cmp "${TEST_DIR}/${TEST_KEY}.err" "${TEST_KEY}.err" <'/dev/null'
+run_pass "${TEST_KEY}.out" \
+    grep -q -F "Deleting branch ${REPOS_URL}/a/a/0/0/0/my-branch ..." \
+    "../${TEST_KEY}.out"
+teardown
+#-------------------------------------------------------------------------------
+exit

--- a/t/lib/bash/svn_test_header
+++ b/t/lib/bash/svn_test_header
@@ -99,9 +99,8 @@ function init_repos_layout_roses() {
         svnadmin create --fs-type fsfs $TEST_DIR/test_repos
         REPOS_URL="file://$TEST_DIR/test_repos"
     fi
-    svn mkdir -q --parents $REPOS_URL/a/a/0/0/0/trunk
     svn import -q $TEST_SOURCE_DIR/../etc/repo_files \
-        $REPOS_URL/a/a/0/0/0/trunk -m "initial trunk import"
+        $REPOS_URL/a/a/0/0/0/trunk/ -m "initial trunk import"
     TMPFILE=$(mktemp)
     cat >$TMPFILE <<__LAYOUT__
 depth-project = 5


### PR DESCRIPTION
`fcm branch-delete` was producing Perl undefined variable warning messages on branches of suites in Rosie repositories, due to the fact that it is unable to determine the branch owner using the branch URL. This change fixes the warning message.

@scwhitehouse @paulcresswell please review.