### PR TITLE
fcm switch: fix Perl warning

### DIFF
--- a/lib/FCM1/Cm.pm
+++ b/lib/FCM1/Cm.pm
@@ -1794,7 +1794,9 @@ sub _cm_get_source {
         return _cm_err(FCM1::Cm::Exception->INVALID_BRANCH, $source_url);
     }
     $source->url_peg(
-      $source->branch_url() . '/' . $target->subdir() . '@' . $source->pegrev()
+        $source->branch_url()
+        . ($target->subdir() ? '/' . $target->subdir() : q{})
+        . ('@' . $source->pegrev())
     );
     # Ensure that the source and target URLs are in the same project
     if ($source->project_url() ne $target->project_url()) {


### PR DESCRIPTION
This happened on an unexpected usage. A user has checked out an entire
project tree, and then run `fcm switch trunk` on it. Clearly it did not
work, but the added Perl warning was not helpful either.

@scwhitehouse Please review. I don't think we need a 2nd reviewer for this.