### PR TITLE
fcm make build prop: link-without-ar

### DIFF
--- a/doc/user_guide/annex_cfg.html
+++ b/doc/user_guide/annex_cfg.html
@@ -508,6 +508,20 @@ build.prop{fc.flags}[foo/bar] = -O1
   "make.html">FCM Make</a>.</p>
 
   <dl>
+    <dt id="make.description">description</dt>
+
+    <dd>
+      <p><dfn>description</dfn>: Specifies a description string for the current
+      make.</p>
+
+      <p><dfn>value</dfn>: A string.</p>
+
+      <p><dfn>example</dfn>:</p>
+      <pre>
+description = Release 2.71.82
+</pre>
+    </dd>
+
     <dt id="make.dest">dest</dt>
 
     <dd>

--- a/doc/user_guide/annex_cfg.html
+++ b/doc/user_guide/annex_cfg.html
@@ -508,20 +508,6 @@ build.prop{fc.flags}[foo/bar] = -O1
   "make.html">FCM Make</a>.</p>
 
   <dl>
-    <dt id="make.description">description</dt>
-
-    <dd>
-      <p><dfn>description</dfn>: Specifies a description string for the current
-      make.</p>
-
-      <p><dfn>value</dfn>: A string.</p>
-
-      <p><dfn>example</dfn>:</p>
-      <pre>
-description = Release 2.71.82
-</pre>
-    </dd>
-
     <dt id="make.dest">dest</dt>
 
     <dd>
@@ -1336,13 +1322,27 @@ build.prop{fc.libs}[myprog.exe] = netcdf grib
 
     <dt id="make.build.prop.keep-lib-o">keep-lib-o</dt>
 
-    <dd>Obsolete. This setting does nothing and is retained only for backward
-    compatibility.</dd>
+    <dd>Relevant when linking a binary executable and <a href=
+    "#make.build.prop.link-without-ar">link-without-ar</a> is not set to
+    <kbd>true</kbd>. If <kbd>true</kbd>, create and keep the dependent object
+    library as <samp>lib/libNAME.a</samp>, where <var>NAME</var> is the root
+    name of the executable. In the absence of this setting, the behaviour is to
+    create the dependent object library in a temporary directory, which is
+    removed after the linker command is completed.</dd>
 
     <dt id="make.build.prop.ld">ld</dt>
 
     <dd>The linker command. If not specified, use the compiler of the source
     file.</dd>
+
+    <dt id="make.build.prop.link-without-ar">link-without-ar</dt>
+
+    <dd>Relevant when linking a binary executable. If <kbd>true</kbd>, do not
+    create the dependent object library when linking. Instead, locations of the
+    dependent objects will be specified on the command line of the linker. In
+    the absence of this setting, the behaviour is to create the dependent object
+    library in a temporary directory, with the location of the object library
+    specified using the relevant options of the linker.</dd>
 
     <dt id="make.build.prop.no-dep.bin">no-dep.bin</dt>
 

--- a/t/fcm-make/01-build-link-opts.t
+++ b/t/fcm-make/01-build-link-opts.t
@@ -19,11 +19,53 @@
 #-------------------------------------------------------------------------------
 # Tests some linker options for "fcm make".
 #-------------------------------------------------------------------------------
-. $(dirname $0)/test_header
+. "$(dirname "$0")/test_header"
 #-------------------------------------------------------------------------------
-tests 5
-cp -r $TEST_SOURCE_DIR/$TEST_KEY_BASE/* .
-PATH=$PWD/bin:$PATH
+tests 14
+cp -r "${TEST_SOURCE_DIR}/${TEST_KEY_BASE}/"* .
+PATH="${PWD}/bin:${PATH}"
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}-ld-link-without-ar-new"
+run_pass "${TEST_KEY}" fcm make --new 'build.prop{link-without-ar}=true'
+find 'build' -type f | sort >"${TEST_KEY}.find"
+file_cmp "${TEST_KEY}.find" "${TEST_KEY}.find" <<'__OUT__'
+build/bin/hello.exe
+build/include/world.mod
+build/o/hello.o
+build/o/world.o
+__OUT__
+sed -n 's/^.*\(gfortran -obin.*\)$/\1/p' 'fcm-make.log' >"${TEST_KEY}.log.edited"
+file_cmp "${TEST_KEY}.log.edited" "${TEST_KEY}.log.edited" <<'__OUT__'
+gfortran -obin/hello.exe o/hello.o o/world.o
+__OUT__
+#-------------------------------------------------------------------------------
+TEST_KEY="$TEST_KEY_BASE-keep-lib-o-incr"
+fcm make -q --new
+echo 'build.prop{keep-lib-o} = true' >>fcm-make.cfg
+find build -type f -exec stat -c'%Y %n' {} \; | sort >"$TEST_KEY.mtime.old"
+run_pass "$TEST_KEY" fcm make
+find build -type f -exec stat -c'%Y %n' {} \; | sort >"$TEST_KEY.mtime"
+if cmp -s "$TEST_KEY.mtime.old" "$TEST_KEY.mtime"; then
+    fail "$TEST_KEY.mtime"
+else
+    pass "$TEST_KEY.mtime"
+fi
+file_grep "$TEST_KEY.mtime.grep" 'lib/libhello[.]a' "$TEST_KEY.mtime"
+sed -i '/hello[.]exe/d' "$TEST_KEY.mtime.old"
+sed -i '/libhello[.]a/d; /hello[.]exe/d' "$TEST_KEY.mtime"
+file_cmp "$TEST_KEY.mtime.old" "$TEST_KEY.mtime.old" "$TEST_KEY.mtime"
+#-------------------------------------------------------------------------------
+TEST_KEY="$TEST_KEY_BASE-keep-lib-o-new"
+# echo 'build.prop{keep-lib-o} = true' >>fcm-make.cfg # already done above
+run_pass "$TEST_KEY" fcm make --new
+find build -type f | sort >"$TEST_KEY.find"
+file_cmp "$TEST_KEY.find" "$TEST_KEY.find" <<'__OUT__'
+build/bin/hello.exe
+build/include/world.mod
+build/lib/libhello.a
+build/o/hello.o
+build/o/world.o
+__OUT__
 #-------------------------------------------------------------------------------
 TEST_KEY="$TEST_KEY_BASE-ld-incr"
 cp -r $TEST_SOURCE_DIR/$TEST_KEY_BASE/fcm-make.cfg .


### PR DESCRIPTION
Revert default behaviour to create temporary dependent object library before linking it to executable. (This effectively reverts #245 - as the changed behaviour has raised unforeseen side effects.)

New build property to suppress this.