### PR TITLE
fcm make: build: handle program unit tail comment

### DIFF
--- a/lib/FCM/System/Make/Build/FileType/Fortran.pm
+++ b/lib/FCM/System/Make/Build/FileType/Fortran.pm
@@ -64,9 +64,9 @@ my %RE           = (
     INCLUDE   => qr{\#?\s*include\s*}imsx,
     OMP_SENT  => qr{\A(\s*!\$\s+)?(.*)\z}imsx,
     UNIT_ATTR => qr{\A\s*(?:(?:(?:impure\s+)?elemental|recursive|pure)\s+)+(.*)\z}imsx,
-    UNIT_BASE => qr{\A\s*($RE_UNIT_BASE)\s+($RE_NAME)\s*\z}imsx,
+    UNIT_BASE => qr{\A\s*($RE_UNIT_BASE)\s+($RE_NAME)\b}imsx,
     UNIT_CALL => qr{\A\s*($RE_UNIT_CALL)\s+($RE_NAME)\b}imsx,
-    UNIT_END  => qr{\A\s*(end)(?:\s+($RE_NAME)(?:\s+($RE_NAME))?)?\s*\z}imsx,
+    UNIT_END  => qr{\A\s*(end)(?:\s+($RE_NAME)(?:\s+($RE_NAME))?)?\b}imsx,
     UNIT_SPEC => qr{\A\s*$RE_SPEC\b(.*)\z}imsx,
 );
 

--- a/t/fcm-make/55-build-fortran-prog-unit-tail-comment.t
+++ b/t/fcm-make/55-build-fortran-prog-unit-tail-comment.t
@@ -1,0 +1,42 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# (C) British Crown Copyright 2006-17 Met Office.
+#
+# This file is part of FCM, tools for managing and building source code.
+#
+# FCM is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FCM is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FCM. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test build, handle Fortran program unit with tail comments
+# https://github.com/metomi/fcm/issues/252
+#-------------------------------------------------------------------------------
+. "$(dirname "$0")/test_header"
+tests 5
+#-------------------------------------------------------------------------------
+cp -r "${TEST_SOURCE_DIR}/${TEST_KEY_BASE}/"* '.'
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}"
+
+run_pass "${TEST_KEY}" fcm make
+sed -n '/source->target greet_mod.f90/p' 'fcm-make.log' >'fcm-make.log.edited'
+file_cmp "${TEST_KEY}.target.log" 'fcm-make.log.edited' <<'__LOG__'
+[info] source->target greet_mod.f90 -> (install) include/ greet_mod.f90
+[info] source->target greet_mod.f90 -> (compile+) include/ greet_mod.mod
+[info] source->target greet_mod.f90 -> (compile) o/ greet_mod.o
+__LOG__
+
+run_pass "${TEST_KEY}.greet" "${PWD}/build/bin/greet.exe"
+file_cmp "${TEST_KEY}.greet.out" "${TEST_KEY}.greet.out" <<<'Greet World'
+file_cmp "${TEST_KEY}.greet.err" "${TEST_KEY}.greet.err" <'/dev/null'
+#-------------------------------------------------------------------------------
+exit 0

--- a/t/fcm-make/55-build-fortran-prog-unit-tail-comment/fcm-make.cfg
+++ b/t/fcm-make/55-build-fortran-prog-unit-tail-comment/fcm-make.cfg
@@ -1,0 +1,3 @@
+steps=build
+build.source=$HERE/src
+build.target{task}=link

--- a/t/fcm-make/55-build-fortran-prog-unit-tail-comment/src/greet.f90
+++ b/t/fcm-make/55-build-fortran-prog-unit-tail-comment/src/greet.f90
@@ -1,0 +1,4 @@
+program greet
+use greet_mod, only: greet_world
+call greet_world()
+end program greet

--- a/t/fcm-make/55-build-fortran-prog-unit-tail-comment/src/greet_mod.f90
+++ b/t/fcm-make/55-build-fortran-prog-unit-tail-comment/src/greet_mod.f90
@@ -1,0 +1,6 @@
+module greet_mod ! a greeting module for testing
+contains
+subroutine greet_world()
+write(*, '(a)') 'Greet World'
+end subroutine greet_world
+end module greet_mod ! world does not end here


### PR DESCRIPTION
Fortran dependency analysis was not handling tail comment of a program unit correctly.

Fix #252.