### PR TITLE
fcm make build: correctly support Fortran submodule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,26 +2,31 @@
 # See https://travis-ci.org/ for more info.
 
 ---
+dist: xenial
 language: perl
+perl:
+    - "5.26"
+    - "5.28"
+    - "5.30"
 
 before_install:
-    - cat >"${HOME}/.bashrc" <<<"export PATH=${PWD}/bin:\$PATH"
+    - echo "export PATH=${PWD}/bin:\${PATH}" >>"${HOME}/.bashrc"
+    - echo "#!/bin/bash" >"${PWD}/bin/gfortran"
+    - echo 'exec gfortran-9 "$@"' >>"${PWD}/bin/gfortran"
+    - chmod +x "${PWD}/bin/gfortran"
     - source "${HOME}/.bashrc"
 
 install: 
-    - sudo apt-get install -y build-essential gfortran
-    - sudo apt-get install -y libxml-parser-perl libconfig-inifiles-perl
-    - sudo apt-get install -y libdbi-perl libdbd-sqlite3-perl
-    # For some reason XML::Parser needs to be installed this way
-    - cpanm 'Config::IniFiles' 'XML::Parser'
-    # Latest Subversion
-    - sudo sh -c 'echo "deb http://opensource.wandisco.com/ubuntu `lsb_release -cs` svn19" >> /etc/apt/sources.list.d/subversion19.list'
-    - sudo wget -q http://opensource.wandisco.com/wandisco-debian.gpg -O- | sudo apt-key add -
-    - sudo apt-get update
-    - sudo apt-get install -y subversion libsvn-perl python-subversion
-    - sudo apt-get install -y heirloom-mailx
-    - sudo apt-get install -y python-pip
-    - sudo pip install trac
+    - sudo add-apt-repository -y 'ppa:ubuntu-toolchain-r/test'
+    - sudo apt update
+    - sudo apt install -y 'build-essential' 'gfortran-9'
+    - sudo apt install -y 'libconfig-inifiles-perl' 'libxml-parser-perl'
+    - sudo apt install -y 'libdbi-perl' 'libdbd-sqlite3-perl'
+    - sudo apt install -y 'subversion' 'python-subversion' 'libsvn-perl'
+    - sudo apt install -y 'heirloom-mailx'
+    - sudo apt install -y 'python-pip'
+    - sudo pip install 'trac'
+    - cpanm 'Config::IniFiles' 'DBI' 'DBD::SQLite' 'XML::Parser'
 
 script: 
     - fcm test-battery -j 5

--- a/t/fcm-make/56-build-fortran-submodule.t
+++ b/t/fcm-make/56-build-fortran-submodule.t
@@ -1,0 +1,53 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------
+# Copyright (C) 2006-2019 British Crown (Met Office) & Contributors.
+#
+# This file is part of FCM, tools for managing and building source code.
+#
+# FCM is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FCM is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with FCM. If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+# Test build, handle Fortran submodule
+#-------------------------------------------------------------------------------
+. "$(dirname "$0")/test_header"
+tests 5
+#-------------------------------------------------------------------------------
+cp -r "${TEST_SOURCE_DIR}/${TEST_KEY_BASE}/"* '.'
+#-------------------------------------------------------------------------------
+TEST_KEY="${TEST_KEY_BASE}"
+
+run_pass "${TEST_KEY}" fcm make
+sed -n '/\[info\] target /p' 'fcm-make.log' >'fcm-make.log.edited'
+file_cmp "${TEST_KEY}.target.log" 'fcm-make.log.edited' <<'__LOG__'
+[info] target test.exe
+[info] target  - class_impl.o
+[info] target  - class_mod.o
+[info] target  - simple_impl.o
+[info] target  - simple_mod.o
+[info] target  - test.o
+[info] target  -  - class_mod.mod
+[info] target  -  -  - class_mod.o
+[info] target  -  - simple_mod.mod
+[info] target  -  -  - simple_mod.o
+__LOG__
+
+run_pass "${TEST_KEY}.test" "${PWD}/build/bin/test.exe"
+file_cmp "${TEST_KEY}.test.out" "${TEST_KEY}.test.out" <<'__OUT__'
+Returner 14
+
+Start with 12
+After mangle 29
+__OUT__
+file_cmp "${TEST_KEY}.test.err" "${TEST_KEY}.test.err" <'/dev/null'
+#-------------------------------------------------------------------------------
+exit 0

--- a/t/fcm-make/56-build-fortran-submodule/fcm-make.cfg
+++ b/t/fcm-make/56-build-fortran-submodule/fcm-make.cfg
@@ -1,0 +1,3 @@
+steps = build
+build.source = $HERE/src
+build.target{task} = link

--- a/t/fcm-make/56-build-fortran-submodule/src/class_impl.f90
+++ b/t/fcm-make/56-build-fortran-submodule/src/class_impl.f90
@@ -1,0 +1,27 @@
+submodule(class_mod) class_impl
+
+  implicit none
+
+contains
+
+  module function bar_initialiser( starter ) result(instance)
+    implicit none
+    integer, intent(in) :: starter
+    type(bar_type) :: instance
+    instance%stuff = starter
+  end function bar_initialiser
+
+
+  module subroutine bar_mangle(this, factor)
+    implicit none
+    class(bar_type), intent(inout) :: this
+    integer,         intent(in)    :: factor
+    this%stuff = ieor(this%stuff, factor)
+  end subroutine bar_mangle
+
+
+  module procedure bar_howmuch ! Alternative syntax
+    bar_howmuch = this%stuff
+  end procedure bar_howmuch
+
+end submodule class_impl

--- a/t/fcm-make/56-build-fortran-submodule/src/class_mod.f90
+++ b/t/fcm-make/56-build-fortran-submodule/src/class_mod.f90
@@ -1,0 +1,54 @@
+module class_mod
+
+  implicit none
+
+  type, abstract :: foo_type
+    private
+    integer :: stuff
+  contains
+    private
+    procedure(mangle_if),   public, deferred :: mangle
+    procedure(how_much_if), public, deferred :: how_much
+  end type foo_type
+
+  interface
+    subroutine mangle_if(this, factor)
+      import foo_type
+      class(foo_type), intent(inout) :: this
+      integer,         intent(in) :: factor
+    end subroutine mangle_if
+    function how_much_if(this)
+      import foo_type
+      class(foo_type), intent(inout) :: this
+      integer :: how_much_if
+    end function how_much_if
+  end interface
+
+  type, extends(foo_type) :: bar_type
+    private
+  contains
+    private
+    procedure, public :: mangle   => bar_mangle
+    procedure, public :: how_much => bar_howmuch
+  end type bar_type
+
+  interface bar_type
+    procedure bar_initialiser
+  end interface bar_type
+
+  interface
+    module function bar_initialiser(starter) result(instance)
+      integer,intent(in) :: starter
+      type(bar_type) :: instance
+    end function bar_initialiser
+    module subroutine bar_mangle(this, factor)
+      class(bar_type), intent(inout) :: this
+      integer,         intent(in) :: factor
+    end subroutine bar_mangle
+    module function bar_howmuch(this)
+      class(bar_type), intent(inout) :: this
+      integer :: bar_howmuch
+    end function bar_howmuch
+  end interface
+
+end module class_mod

--- a/t/fcm-make/56-build-fortran-submodule/src/simple_impl.f90
+++ b/t/fcm-make/56-build-fortran-submodule/src/simple_impl.f90
@@ -1,0 +1,18 @@
+submodule(simple_mod) simple_impl
+
+  implicit none
+
+contains
+
+  module function returnerer(thing)
+
+    implicit none
+
+    integer, intent(in) :: thing
+    integer :: returnerer
+
+    returnerer = 2 * thing
+
+  end function returnerer
+
+end submodule simple_impl

--- a/t/fcm-make/56-build-fortran-submodule/src/simple_mod.f90
+++ b/t/fcm-make/56-build-fortran-submodule/src/simple_mod.f90
@@ -1,0 +1,13 @@
+module simple_mod
+
+  implicit none
+
+  interface
+    module function returnerer(thing)
+      implicit none
+      integer, intent(in) :: thing
+      integer :: returnerer
+    end function returnerer
+  end interface
+
+end module simple_mod

--- a/t/fcm-make/56-build-fortran-submodule/src/test.f90
+++ b/t/fcm-make/56-build-fortran-submodule/src/test.f90
@@ -1,0 +1,21 @@
+program test
+
+  use iso_fortran_env, only : output_unit
+
+  use class_mod,  only : bar_type
+  use simple_mod, only : returnerer
+
+  implicit none
+
+  type(bar_type) :: thing
+
+  thing = bar_type(12)
+
+  write(output_unit, '("Returner ", I0)') returnerer(7)
+  write(output_unit, '()')
+
+  write(output_unit, '("Start with ", I0)') thing%how_much()
+  call thing%mangle(17)
+  write(output_unit, '("After mangle ", I0)') thing%how_much()
+
+end program test


### PR DESCRIPTION
Fix #255.

Complete with test for building Fortran code with submodules, borrowed from fab.

Note on building a Fortran submodule.
* The source file containing the submodule has a compile time dependency on the `*.mod` of the parent module. (This is already handled in the logic, the the current regular expression is a bit flawed.)
* The source file containing the parent module has a link time dependency on the `*.o` file containing the submodule. (This is handled by the new *reverse dependency* logic.)

Note on Travis CI:
* Upgrade to use Ubuntu 16.04 xenial, latest distro available on Travis CI.
* Need to install `gfortran-9` separately (for Fortran 2008+) features, and wrap it so the `gfortran` command executes `gfortran-9`.
* Install Subversion normally, which should be good enough on this version of Ubuntu. Wandisco's version is probably no longer supported.