### PR TITLE
Add space to fortran module regexp

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,8 @@ below:
 * Roddy Sharp (Met Office, UK)
 * Matt Shin (Met Office, UK)
 * Stuart Whitehouse (Met Office, UK)
-* Tim Pillinger (Met Office, U)
+* Tim Pillinger (Met Office, UK)
+* Joe Mancell (Met Office, UK)
 
 (All contributors are identifiable with email addresses in the version
 control logs or otherwise.)

--- a/lib/FCM/System/Make/Build/FileType/Fortran.pm
+++ b/lib/FCM/System/Make/Build/FileType/Fortran.pm
@@ -57,7 +57,7 @@ my $RE_SPEC = qr{
 }imsx;
 my $RE_UNIT_BASE = qr{
     block\s*data|
-    module(?!\s*(?:function|subroutine|procedure))|
+    module(?!\s*(?:function|subroutine|procedure)\s+)|
     program|
 }imsx;
 my $RE_UNIT_CALL = qr{subroutine|function}imsx;


### PR DESCRIPTION
Add fix for module regexp. Add a space to regexp so that it doesn't incorrectly ignore modules that begin with function/subroutine