### PR TITLE
fcm-add-trac-env: Setup the default repository rather than a named one

### DIFF
--- a/lib/FCM/Admin/System.pm
+++ b/lib/FCM/Admin/System.pm
@@ -175,8 +175,7 @@ sub add_trac_environment {
     if (-d $project->get_svn_live_path()) {
         $TRAC_ADMIN->(
             "adding repository",
-            qw{repository add},
-            $project->get_name(),
+            qw{repository add (default)},
             $project->get_svn_live_path(),
         );
     }

--- a/t/fcm-add-trac-env/00-basic.t
+++ b/t/fcm-add-trac-env/00-basic.t
@@ -64,7 +64,7 @@ for NAME in bus car lorry taxi; do
         run_pass "${TEST_KEY}-repos-list" \
             trac-admin "${PWD}/srv/trac/${NAME}" repository list
         file_grep "${TEST_KEY}-repos-list.out" \
-            "${NAME} *${PWD}/srv/svn/${NAME}"  "${TEST_KEY}-repos-list.out"
+            "(default) *${PWD}/srv/svn/${NAME}"  "${TEST_KEY}-repos-list.out"
     fi
 done
 


### PR DESCRIPTION
#258 changed the behaviour of `fcm-add-trac-env` to add a named repository rather than the default - this PR reproduces the old behaviour.