### PR TITLE
Simplify github actions test environments

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,42 +3,38 @@ on: [pull_request, workflow_dispatch]
 jobs:
   test:
     strategy:
+      fail-fast: False
       matrix:
-        ubuntu: ['ubuntu-16.04', 'ubuntu-18.04']
+        ubuntu: ['ubuntu-16.04', 'ubuntu-18.04', 'ubuntu-20.04']
     name: FCM Tests ${{matrix.ubuntu}}
     runs-on: ${{matrix.ubuntu}}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install
+        run: |
+          sudo apt update
+          sudo apt install -y \
+            gfortran-9 \
+            libconfig-inifiles-perl \
+            libxml-parser-perl \
+            libdbi-perl \
+            libdbd-sqlite3-perl \
+            python-subversion libsvn-perl \
+            s-nail
+          [[ ${{matrix.ubuntu}} != "ubuntu-20.04" ]] && sudo pip install 'trac' || true
+          echo "#!/bin/bash" >"${PWD}/bin/gfortran"
+          echo 'exec gfortran-9 "$@"' >>"${PWD}/bin/gfortran"
+          chmod +x "${PWD}/bin/gfortran"
+
       - name: Check Perl Version
         run: perl --version
 
       - name: Check SVN Version
         run: svn --version
-
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Pre-Install
-        run: |
-          echo "export PATH=${PWD}/bin:\${PATH}" >>"${HOME}/.bashrc"
-          echo "#!/bin/bash" >"${PWD}/bin/gfortran"
-          echo 'exec gfortran-9 "$@"' >>"${PWD}/bin/gfortran"
-          chmod +x "${PWD}/bin/gfortran"
-          source "${HOME}/.bashrc"
-
-      - name: Install
-        run: |
-          sudo add-apt-repository -y 'ppa:ubuntu-toolchain-r/test'
-          sudo add-apt-repository universe
-          sudo apt update
-          sudo apt install -y 'cpanminus'
-          sudo apt install -y 'build-essential' 'gfortran-9'
-          sudo apt install -y 'libconfig-inifiles-perl' 'libxml-parser-perl'
-          sudo apt install -y 'libdbi-perl' 'libdbd-sqlite3-perl'
-          sudo apt install -y 'subversion' 'python-subversion' 'libsvn-perl'
-          sudo apt install -y 's-nail'  # Provides mailx
-          sudo apt install -y 'python-pip'
-          sudo pip install 'trac'
-          cpanm 'Config::IniFiles' 'DBI' 'DBD::SQLite' 'XML::Parser'
 
       - name: Run tests
         run: |

--- a/sbin/svnperms.py
+++ b/sbin/svnperms.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 #
 #

--- a/t/fcm-make/23-build-omp.t
+++ b/t/fcm-make/23-build-omp.t
@@ -23,8 +23,8 @@
 #-------------------------------------------------------------------------------
 tests 16
 cp -r $TEST_SOURCE_DIR/$TEST_KEY_BASE/* .
-yes 6.0 | head -n 100 >"$TEST_KEY_BASE.exe.on.out"
-yes 1.0 | head -n 100 >"$TEST_KEY_BASE.exe.off.out"
+printf '6.0\n%.0s' {1..100} >"$TEST_KEY_BASE.exe.on.out"
+printf '1.0\n%.0s' {1..100} >"$TEST_KEY_BASE.exe.off.out"
 #-------------------------------------------------------------------------------
 TEST_KEY=$TEST_KEY_BASE-on # fc.flag-omp on in new mode
 run_pass "$TEST_KEY" fcm make

--- a/t/lib/bash/test_header
+++ b/t/lib/bash/test_header
@@ -234,7 +234,7 @@ function commit_sort() {
     # Sort the svn status part of the message
     status_sort $INPUT_FILE $TMP_OUTPUT_FILE
     # Sort the 'Adding/Deleting', etc part of the message
-    python -c 'import re, sys
+    python2 -c 'import re, sys
 text = sys.stdin.read()
 sending_lines = re.findall("^\w+ing  +.*$", text, re.M)
 prefix = text[:text.index(sending_lines[0])]
@@ -252,7 +252,7 @@ function diff_sort() {
     local INPUT_FILE=$1
     local OUTPUT_FILE=$2
     # Sort the diff file order.
-    python -c 'import re, sys
+    python2 -c 'import re, sys
 text = sys.stdin.read()
 print "\nIndex: ".join(
     [l.strip() for l in sorted(re.compile("^Index: ", re.M).split(text))])
@@ -264,7 +264,7 @@ print "\nIndex: ".join(
 function status_sort() {
     local INPUT_FILE=$1
     local OUTPUT_FILE=$2
-    python -c 'import re, sys
+    python2 -c 'import re, sys
 text = sys.stdin.read()
 status_lines = re.findall("^.{7} [\w./].*$", text, re.M)
 prefix = text[:text.index(status_lines[0])]
@@ -277,7 +277,7 @@ print prefix + "\n".join(status_lines) + suffix.rstrip()
 function merge_sort() {
     local INPUT_FILE=$1
     local OUTPUT_FILE=$2
-    python -c 'import re, sys
+    python2 -c 'import re, sys
 text = sys.stdin.read()
 status_lines = []
 for line in text.splitlines():
@@ -303,8 +303,8 @@ if status_lines:
 }
 
 function check_svn_version() {
-    if ! svn --version | head -1 | grep -q "^svn, version 1\.\(8\|9\|10\)"; then
-        skip_all "Tests require Subversion 1.8, 1.9 or 1.10"
+    if [[ ! $SVN_MINOR_VERSION =~ ^1\.(8|9|10)$ ]]; then
+        skip_all "Tests require Subversion 1.8 or later"
         exit 0
     fi
 }
@@ -336,6 +336,8 @@ SVN_MINOR_VERSION=undef
 if svn --version 1>/dev/null 2>&1; then
     SVN_MINOR_VERSION=$(svn --version | \
                         sed -n "s/^svn, version 1.\([0-9]\+\)\.[0-9]\+ .*/1.\1/p")
+    # Treat versions 1.10 and above the same for the moment
+    [[ $SVN_MINOR_VERSION =~ ^1\.1[0-9]$ ]] && SVN_MINOR_VERSION=1.10
 fi
 
 TEST_KEY_BASE=$(basename $0 .t)


### PR DESCRIPTION
Add Ubuntu 20.04.

Treat Subversion version 1.10 and above the same.

Use python2 in place of python in tests and in svnperms.py.

Replace the use of "yes" (to avoid warning messages) following this advice:
https://superuser.com/questions/86340/linux-command-to-repeat-a-string-n-times

Prevent other jobs being cancelled if one fails:
https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast

Checkout all history (git describe fails without this):
https://github.com/actions/checkout#Fetch-all-history-for-all-tags-and-branches