### PR TITLE
Modify tests to work with svn 1.14

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,12 +5,12 @@ jobs:
     strategy:
       fail-fast: False
       matrix:
-        ubuntu: ['ubuntu-18.04', 'ubuntu-20.04']
+        ubuntu: ['ubuntu-20.04', 'ubuntu-22.04']
     name: FCM Tests ${{matrix.ubuntu}}
     runs-on: ${{matrix.ubuntu}}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -23,9 +23,11 @@ jobs:
             libxml-parser-perl \
             libdbi-perl \
             libdbd-sqlite3-perl \
-            python-subversion libsvn-perl \
-            s-nail
-          [[ ${{matrix.ubuntu}} == "ubuntu-18.04" ]] && sudo pip install 'trac' || true
+            libsvn-perl \
+            s-nail \
+            subversion
+          [[ ${{matrix.ubuntu}} != "ubuntu-22.04" ]] && sudo apt install -y python-subversion || true
+          [[ ${{matrix.ubuntu}} == "ubuntu-22.04" ]] && sudo apt install -y python2 || true
           echo "#!/bin/bash" >"${PWD}/bin/gfortran"
           echo 'exec gfortran-9 "$@"' >>"${PWD}/bin/gfortran"
           chmod +x "${PWD}/bin/gfortran"

--- a/t/fcm-branch-diff/00-simple.t
+++ b/t/fcm-branch-diff/00-simple.t
@@ -62,8 +62,8 @@ Index: added_directory/hello_constants.f90
 ===================================================================
 #IF SVN1.8 --- added_directory/hello_constants.f90	($ROOT_URL/trunk)	(revision 0)
 #IF SVN1.8 +++ added_directory/hello_constants.f90	(revision 6)
-#IF SVN1.9/10 --- added_directory/hello_constants.f90	(.../trunk)	(working copy)
-#IF SVN1.9/10 +++ added_directory/hello_constants.f90	(.../branches/dev/Share/branch_test)	(revision 6)
+#IF SVN1.9/10/14 --- added_directory/hello_constants.f90	(.../trunk)	(working copy)
+#IF SVN1.9/10/14 +++ added_directory/hello_constants.f90	(.../branches/dev/Share/branch_test)	(revision 6)
 @@ -0,0 +1,5 @@
 +MODULE Hello_Constants
 +
@@ -74,8 +74,8 @@ Index: added_directory/hello_constants.inc
 ===================================================================
 #IF SVN1.8 --- added_directory/hello_constants.inc	($ROOT_URL/trunk)	(revision 0)
 #IF SVN1.8 +++ added_directory/hello_constants.inc	(revision 6)
-#IF SVN1.9/10 --- added_directory/hello_constants.inc	(.../trunk)	(working copy)
-#IF SVN1.9/10 +++ added_directory/hello_constants.inc	(.../branches/dev/Share/branch_test)	(revision 6)
+#IF SVN1.9/10/14 --- added_directory/hello_constants.inc	(.../trunk)	(working copy)
+#IF SVN1.9/10/14 +++ added_directory/hello_constants.inc	(.../branches/dev/Share/branch_test)	(revision 6)
 @@ -0,0 +1,2 @@
 +CHARACTER (
 +LEN=80), PARAMETER :: hello_strINg = 'Hello Earth!!'
@@ -83,24 +83,24 @@ Index: added_directory/hello_constants_dummy.inc
 ===================================================================
 #IF SVN1.8 --- added_directory/hello_constants_dummy.inc	($ROOT_URL/trunk)	(revision 0)
 #IF SVN1.8 +++ added_directory/hello_constants_dummy.inc	(revision 6)
-#IF SVN1.9/10 --- added_directory/hello_constants_dummy.inc	(.../trunk)	(working copy)
-#IF SVN1.9/10 +++ added_directory/hello_constants_dummy.inc	(.../branches/dev/Share/branch_test)	(revision 6)
+#IF SVN1.9/10/14 --- added_directory/hello_constants_dummy.inc	(.../trunk)	(working copy)
+#IF SVN1.9/10/14 +++ added_directory/hello_constants_dummy.inc	(.../branches/dev/Share/branch_test)	(revision 6)
 @@ -0,0 +1 @@
 +INCLUDE 'hello_constants.INc'
 Index: added_file
 ===================================================================
 #IF SVN1.8 --- added_file	($ROOT_URL/trunk)	(revision 0)
 #IF SVN1.8 +++ added_file	(revision 6)
-#IF SVN1.9/10 --- added_file	(.../trunk)	(working copy)
-#IF SVN1.9/10 +++ added_file	(.../branches/dev/Share/branch_test)	(revision 6)
+#IF SVN1.9/10/14 --- added_file	(.../trunk)	(working copy)
+#IF SVN1.9/10/14 +++ added_file	(.../branches/dev/Share/branch_test)	(revision 6)
 @@ -0,0 +1 @@
 +INCLUDE 'hello_constants.INc'
 Index: lib/python/info/poems.py
 ===================================================================
 #IF SVN1.8 --- lib/python/info/poems.py	($ROOT_URL/trunk)	(revision 1)
 #IF SVN1.8 +++ lib/python/info/poems.py	(working copy)
-#IF SVN1.9/10 --- lib/python/info/poems.py	(.../trunk)	(revision 1)
-#IF SVN1.9/10 +++ lib/python/info/poems.py	(.../branches/dev/Share/branch_test)	(working copy)
+#IF SVN1.9/10/14 --- lib/python/info/poems.py	(.../trunk)	(revision 1)
+#IF SVN1.9/10/14 +++ lib/python/info/poems.py	(.../branches/dev/Share/branch_test)	(working copy)
 @@ -1,24 +1,23 @@
 -#!/usr/bin/env python
 -# -*- coding: utf-8 -*-
@@ -139,8 +139,8 @@ Index: module/hello_constants.f90
 ===================================================================
 #IF SVN1.8 --- module/hello_constants.f90	($ROOT_URL/trunk)	(revision 1)
 #IF SVN1.8 +++ module/hello_constants.f90	(working copy)
-#IF SVN1.9/10 --- module/hello_constants.f90	(.../trunk)	(revision 1)
-#IF SVN1.9/10 +++ module/hello_constants.f90	(.../branches/dev/Share/branch_test)	(working copy)
+#IF SVN1.9/10/14 --- module/hello_constants.f90	(.../trunk)	(revision 1)
+#IF SVN1.9/10/14 +++ module/hello_constants.f90	(.../branches/dev/Share/branch_test)	(working copy)
 @@ -1,5 +0,0 @@
 -MODULE Hello_Constants
 -
@@ -151,16 +151,16 @@ Index: module/hello_constants.inc
 ===================================================================
 #IF SVN1.8 --- module/hello_constants.inc	($ROOT_URL/trunk)	(revision 1)
 #IF SVN1.8 +++ module/hello_constants.inc	(working copy)
-#IF SVN1.9/10 --- module/hello_constants.inc	(.../trunk)	(revision 1)
-#IF SVN1.9/10 +++ module/hello_constants.inc	(.../branches/dev/Share/branch_test)	(working copy)
+#IF SVN1.9/10/14 --- module/hello_constants.inc	(.../trunk)	(revision 1)
+#IF SVN1.9/10/14 +++ module/hello_constants.inc	(.../branches/dev/Share/branch_test)	(working copy)
 @@ -1 +0,0 @@
 -CHARACTER (LEN=80), PARAMETER :: hello_string = 'Hello Earth!'
 Index: module/hello_constants_dummy.inc
 ===================================================================
 #IF SVN1.8 --- module/hello_constants_dummy.inc	($ROOT_URL/trunk)	(revision 1)
 #IF SVN1.8 +++ module/hello_constants_dummy.inc	(working copy)
-#IF SVN1.9/10 --- module/hello_constants_dummy.inc	(.../trunk)	(revision 1)
-#IF SVN1.9/10 +++ module/hello_constants_dummy.inc	(.../branches/dev/Share/branch_test)	(working copy)
+#IF SVN1.9/10/14 --- module/hello_constants_dummy.inc	(.../trunk)	(revision 1)
+#IF SVN1.9/10/14 +++ module/hello_constants_dummy.inc	(.../branches/dev/Share/branch_test)	(working copy)
 @@ -1 +0,0 @@
 -INCLUDE 'hello_constants.inc'
 __OUT__
@@ -176,8 +176,8 @@ Index: added_directory/hello_constants.f90
 ===================================================================
 #IF SVN1.8 --- added_directory/hello_constants.f90	($ROOT_URL/trunk)	(revision 0)
 #IF SVN1.8 +++ added_directory/hello_constants.f90	(revision 6)
-#IF SVN1.9/10 --- added_directory/hello_constants.f90	(.../trunk)	(working copy)
-#IF SVN1.9/10 +++ added_directory/hello_constants.f90	(.../branches/dev/Share/branch_test)	(revision 6)
+#IF SVN1.9/10/14 --- added_directory/hello_constants.f90	(.../trunk)	(working copy)
+#IF SVN1.9/10/14 +++ added_directory/hello_constants.f90	(.../branches/dev/Share/branch_test)	(revision 6)
 @@ -0,0 +1,5 @@
 +MODULE Hello_Constants
 +
@@ -188,8 +188,8 @@ Index: added_directory/hello_constants.inc
 ===================================================================
 #IF SVN1.8 --- added_directory/hello_constants.inc	($ROOT_URL/trunk)	(revision 0)
 #IF SVN1.8 +++ added_directory/hello_constants.inc	(revision 6)
-#IF SVN1.9/10 --- added_directory/hello_constants.inc	(.../trunk)	(working copy)
-#IF SVN1.9/10 +++ added_directory/hello_constants.inc	(.../branches/dev/Share/branch_test)	(revision 6)
+#IF SVN1.9/10/14 --- added_directory/hello_constants.inc	(.../trunk)	(working copy)
+#IF SVN1.9/10/14 +++ added_directory/hello_constants.inc	(.../branches/dev/Share/branch_test)	(revision 6)
 @@ -0,0 +1,2 @@
 +CHARACTER (
 +LEN=80), PARAMETER :: hello_strINg = 'Hello Earth!!'
@@ -197,24 +197,24 @@ Index: added_directory/hello_constants_dummy.inc
 ===================================================================
 #IF SVN1.8 --- added_directory/hello_constants_dummy.inc	($ROOT_URL/trunk)	(revision 0)
 #IF SVN1.8 +++ added_directory/hello_constants_dummy.inc	(revision 6)
-#IF SVN1.9/10 --- added_directory/hello_constants_dummy.inc	(.../trunk)	(working copy)
-#IF SVN1.9/10 +++ added_directory/hello_constants_dummy.inc	(.../branches/dev/Share/branch_test)	(revision 6)
+#IF SVN1.9/10/14 --- added_directory/hello_constants_dummy.inc	(.../trunk)	(working copy)
+#IF SVN1.9/10/14 +++ added_directory/hello_constants_dummy.inc	(.../branches/dev/Share/branch_test)	(revision 6)
 @@ -0,0 +1 @@
 +INCLUDE 'hello_constants.INc'
 Index: added_file
 ===================================================================
 #IF SVN1.8 --- added_file	($ROOT_URL/trunk)	(revision 0)
 #IF SVN1.8 +++ added_file	(revision 6)
-#IF SVN1.9/10 --- added_file	(.../trunk)	(working copy)
-#IF SVN1.9/10 +++ added_file	(.../branches/dev/Share/branch_test)	(revision 6)
+#IF SVN1.9/10/14 --- added_file	(.../trunk)	(working copy)
+#IF SVN1.9/10/14 +++ added_file	(.../branches/dev/Share/branch_test)	(revision 6)
 @@ -0,0 +1 @@
 +INCLUDE 'hello_constants.INc'
 Index: lib/python/info/poems.py
 ===================================================================
 #IF SVN1.8 --- lib/python/info/poems.py	($ROOT_URL/trunk)	(revision 1)
 #IF SVN1.8 +++ lib/python/info/poems.py	(working copy)
-#IF SVN1.9/10 --- lib/python/info/poems.py	(.../trunk)	(revision 1)
-#IF SVN1.9/10 +++ lib/python/info/poems.py	(.../branches/dev/Share/branch_test)	(working copy)
+#IF SVN1.9/10/14 --- lib/python/info/poems.py	(.../trunk)	(revision 1)
+#IF SVN1.9/10/14 +++ lib/python/info/poems.py	(.../branches/dev/Share/branch_test)	(working copy)
 @@ -1,24 +1,23 @@
 -#!/usr/bin/env python
 -# -*- coding: utf-8 -*-
@@ -253,8 +253,8 @@ Index: module/hello_constants.f90
 ===================================================================
 #IF SVN1.8 --- module/hello_constants.f90	($ROOT_URL/trunk)	(revision 1)
 #IF SVN1.8 +++ module/hello_constants.f90	(working copy)
-#IF SVN1.9/10 --- module/hello_constants.f90	(.../trunk)	(revision 1)
-#IF SVN1.9/10 +++ module/hello_constants.f90	(.../branches/dev/Share/branch_test)	(working copy)
+#IF SVN1.9/10/14 --- module/hello_constants.f90	(.../trunk)	(revision 1)
+#IF SVN1.9/10/14 +++ module/hello_constants.f90	(.../branches/dev/Share/branch_test)	(working copy)
 @@ -1,5 +0,0 @@
 -MODULE Hello_Constants
 -
@@ -265,16 +265,16 @@ Index: module/hello_constants.inc
 ===================================================================
 #IF SVN1.8 --- module/hello_constants.inc	($ROOT_URL/trunk)	(revision 1)
 #IF SVN1.8 +++ module/hello_constants.inc	(working copy)
-#IF SVN1.9/10 --- module/hello_constants.inc	(.../trunk)	(revision 1)
-#IF SVN1.9/10 +++ module/hello_constants.inc	(.../branches/dev/Share/branch_test)	(working copy)
+#IF SVN1.9/10/14 --- module/hello_constants.inc	(.../trunk)	(revision 1)
+#IF SVN1.9/10/14 +++ module/hello_constants.inc	(.../branches/dev/Share/branch_test)	(working copy)
 @@ -1 +0,0 @@
 -CHARACTER (LEN=80), PARAMETER :: hello_string = 'Hello Earth!'
 Index: module/hello_constants_dummy.inc
 ===================================================================
 #IF SVN1.8 --- module/hello_constants_dummy.inc	($ROOT_URL/trunk)	(revision 1)
 #IF SVN1.8 +++ module/hello_constants_dummy.inc	(working copy)
-#IF SVN1.9/10 --- module/hello_constants_dummy.inc	(.../trunk)	(revision 1)
-#IF SVN1.9/10 +++ module/hello_constants_dummy.inc	(.../branches/dev/Share/branch_test)	(working copy)
+#IF SVN1.9/10/14 --- module/hello_constants_dummy.inc	(.../trunk)	(revision 1)
+#IF SVN1.9/10/14 +++ module/hello_constants_dummy.inc	(.../branches/dev/Share/branch_test)	(working copy)
 @@ -1 +0,0 @@
 -INCLUDE 'hello_constants.inc'
 __OUT__
@@ -320,16 +320,16 @@ Index: added_directory/foo00-simple-bdi-wc-changes
 ===================================================================
 #IF SVN1.8 --- added_directory/foo00-simple-bdi-wc-changes	($ROOT_URL/trunk)	(revision 0)
 #IF SVN1.8 +++ added_directory/foo00-simple-bdi-wc-changes	(working copy)
-#IF SVN1.9/10 --- added_directory/foo00-simple-bdi-wc-changes	(.../trunk)	(working copy)
-#IF SVN1.9/10 +++ added_directory/foo00-simple-bdi-wc-changes	(.../branches/dev/Share/branch_test)	(working copy)
+#IF SVN1.9/10/14 --- added_directory/foo00-simple-bdi-wc-changes	(.../trunk)	(working copy)
+#IF SVN1.9/10/14 +++ added_directory/foo00-simple-bdi-wc-changes	(.../branches/dev/Share/branch_test)	(working copy)
 @@ -0,0 +1 @@
 +foo
 Index: added_directory/hello_constants.f90
 ===================================================================
 #IF SVN1.8 --- added_directory/hello_constants.f90	($ROOT_URL/trunk)	(revision 0)
 #IF SVN1.8 +++ added_directory/hello_constants.f90	(revision 6)
-#IF SVN1.9/10 --- added_directory/hello_constants.f90	(.../trunk)	(working copy)
-#IF SVN1.9/10 +++ added_directory/hello_constants.f90	(.../branches/dev/Share/branch_test)	(revision 6)
+#IF SVN1.9/10/14 --- added_directory/hello_constants.f90	(.../trunk)	(working copy)
+#IF SVN1.9/10/14 +++ added_directory/hello_constants.f90	(.../branches/dev/Share/branch_test)	(revision 6)
 @@ -0,0 +1,5 @@
 +MODULE Hello_Constants
 +
@@ -340,8 +340,8 @@ Index: added_directory/hello_constants.inc
 ===================================================================
 #IF SVN1.8 --- added_directory/hello_constants.inc	($ROOT_URL/trunk)	(revision 0)
 #IF SVN1.8 +++ added_directory/hello_constants.inc	(revision 6)
-#IF SVN1.9/10 --- added_directory/hello_constants.inc	(.../trunk)	(working copy)
-#IF SVN1.9/10 +++ added_directory/hello_constants.inc	(.../branches/dev/Share/branch_test)	(revision 6)
+#IF SVN1.9/10/14 --- added_directory/hello_constants.inc	(.../trunk)	(working copy)
+#IF SVN1.9/10/14 +++ added_directory/hello_constants.inc	(.../branches/dev/Share/branch_test)	(revision 6)
 @@ -0,0 +1,2 @@
 +CHARACTER (
 +LEN=80), PARAMETER :: hello_strINg = 'Hello Earth!!'
@@ -349,24 +349,24 @@ Index: added_directory/hello_constants_dummy.inc
 ===================================================================
 #IF SVN1.8 --- added_directory/hello_constants_dummy.inc	($ROOT_URL/trunk)	(revision 0)
 #IF SVN1.8 +++ added_directory/hello_constants_dummy.inc	(revision 6)
-#IF SVN1.9/10 --- added_directory/hello_constants_dummy.inc	(.../trunk)	(working copy)
-#IF SVN1.9/10 +++ added_directory/hello_constants_dummy.inc	(.../branches/dev/Share/branch_test)	(revision 6)
+#IF SVN1.9/10/14 --- added_directory/hello_constants_dummy.inc	(.../trunk)	(working copy)
+#IF SVN1.9/10/14 +++ added_directory/hello_constants_dummy.inc	(.../branches/dev/Share/branch_test)	(revision 6)
 @@ -0,0 +1 @@
 +INCLUDE 'hello_constants.INc'
 Index: added_file
 ===================================================================
 #IF SVN1.8 --- added_file	($ROOT_URL/trunk)	(revision 0)
 #IF SVN1.8 +++ added_file	(revision 6)
-#IF SVN1.9/10 --- added_file	(.../trunk)	(working copy)
-#IF SVN1.9/10 +++ added_file	(.../branches/dev/Share/branch_test)	(revision 6)
+#IF SVN1.9/10/14 --- added_file	(.../trunk)	(working copy)
+#IF SVN1.9/10/14 +++ added_file	(.../branches/dev/Share/branch_test)	(revision 6)
 @@ -0,0 +1 @@
 +INCLUDE 'hello_constants.INc'
 Index: lib/python/info/poems.py
 ===================================================================
 #IF SVN1.8 --- lib/python/info/poems.py	($ROOT_URL/trunk)	(revision 1)
 #IF SVN1.8 +++ lib/python/info/poems.py	(working copy)
-#IF SVN1.9/10 --- lib/python/info/poems.py	(.../trunk)	(revision 1)
-#IF SVN1.9/10 +++ lib/python/info/poems.py	(.../branches/dev/Share/branch_test)	(working copy)
+#IF SVN1.9/10/14 --- lib/python/info/poems.py	(.../trunk)	(revision 1)
+#IF SVN1.9/10/14 +++ lib/python/info/poems.py	(.../branches/dev/Share/branch_test)	(working copy)
 @@ -1,24 +1,23 @@
 -#!/usr/bin/env python
 -# -*- coding: utf-8 -*-
@@ -405,8 +405,8 @@ Index: module/hello_constants.f90
 ===================================================================
 #IF SVN1.8 --- module/hello_constants.f90	($ROOT_URL/trunk)	(revision 1)
 #IF SVN1.8 +++ module/hello_constants.f90	(working copy)
-#IF SVN1.9/10 --- module/hello_constants.f90	(.../trunk)	(revision 1)
-#IF SVN1.9/10 +++ module/hello_constants.f90	(.../branches/dev/Share/branch_test)	(working copy)
+#IF SVN1.9/10/14 --- module/hello_constants.f90	(.../trunk)	(revision 1)
+#IF SVN1.9/10/14 +++ module/hello_constants.f90	(.../branches/dev/Share/branch_test)	(working copy)
 @@ -1,5 +0,0 @@
 -MODULE Hello_Constants
 -
@@ -417,16 +417,16 @@ Index: module/hello_constants.inc
 ===================================================================
 #IF SVN1.8 --- module/hello_constants.inc	($ROOT_URL/trunk)	(revision 1)
 #IF SVN1.8 +++ module/hello_constants.inc	(working copy)
-#IF SVN1.9/10 --- module/hello_constants.inc	(.../trunk)	(revision 1)
-#IF SVN1.9/10 +++ module/hello_constants.inc	(.../branches/dev/Share/branch_test)	(working copy)
+#IF SVN1.9/10/14 --- module/hello_constants.inc	(.../trunk)	(revision 1)
+#IF SVN1.9/10/14 +++ module/hello_constants.inc	(.../branches/dev/Share/branch_test)	(working copy)
 @@ -1 +0,0 @@
 -CHARACTER (LEN=80), PARAMETER :: hello_string = 'Hello Earth!'
 Index: module/hello_constants_dummy.inc
 ===================================================================
 #IF SVN1.8 --- module/hello_constants_dummy.inc	($ROOT_URL/trunk)	(revision 1)
 #IF SVN1.8 +++ module/hello_constants_dummy.inc	(working copy)
-#IF SVN1.9/10 --- module/hello_constants_dummy.inc	(.../trunk)	(revision 1)
-#IF SVN1.9/10 +++ module/hello_constants_dummy.inc	(.../branches/dev/Share/branch_test)	(working copy)
+#IF SVN1.9/10/14 --- module/hello_constants_dummy.inc	(.../trunk)	(revision 1)
+#IF SVN1.9/10/14 +++ module/hello_constants_dummy.inc	(.../branches/dev/Share/branch_test)	(working copy)
 @@ -1 +0,0 @@
 -INCLUDE 'hello_constants.inc'
 __OUT__

--- a/t/fcm-conflicts/00-tree-add-add.t
+++ b/t/fcm-conflicts/00-tree-add-add.t
@@ -22,6 +22,7 @@
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 check_svn_version
+[[ $SVN_VERSION == "1.13.0" ]] && skip_all "Tests do not work with svn 1.13.0"
 tests 24
 #-------------------------------------------------------------------------------
 setup
@@ -56,7 +57,7 @@ Answer (y) to keep the local file filename.
 Answer (n) to keep the external file filename.
 Keep the local version?
 #IF SVN1.8/9 Enter "y" or "n" (or just press <return> for "n") Resolved conflicted state of 'new_file'
-#IF SVN1.10 Enter "y" or "n" (or just press <return> for "n") Tree conflict at 'new_file' marked as resolved.
+#IF SVN1.10/14 Enter "y" or "n" (or just press <return> for "n") Tree conflict at 'new_file' marked as resolved.
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
@@ -116,7 +117,7 @@ Answer (y) to keep the local file filename.
 Answer (n) to keep the external file filename.
 Keep the local version?
 #IF SVN1.8/9 Enter "y" or "n" (or just press <return> for "n") Resolved conflicted state of 'new_file'
-#IF SVN1.10 Enter "y" or "n" (or just press <return> for "n") Tree conflict at 'new_file' marked as resolved.
+#IF SVN1.10/14 Enter "y" or "n" (or just press <return> for "n") Tree conflict at 'new_file' marked as resolved.
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------

--- a/t/fcm-conflicts/01-tree-delete-delete.t
+++ b/t/fcm-conflicts/01-tree-delete-delete.t
@@ -53,7 +53,7 @@ Answer (y) to accept the local delete.
 Answer (n) to accept the external delete.
 Keep the local version?
 #IF SVN1.8/9 Enter "y" or "n" (or just press <return> for "n") Resolved conflicted state of 'pro/hello.pro'
-#IF SVN1.10 Enter "y" or "n" (or just press <return> for "n") Tree conflict at 'pro/hello.pro' marked as resolved.
+#IF SVN1.10/14 Enter "y" or "n" (or just press <return> for "n") Tree conflict at 'pro/hello.pro' marked as resolved.
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
@@ -85,7 +85,7 @@ Answer (y) to accept the local delete.
 Answer (n) to accept the external delete.
 Keep the local version?
 #IF SVN1.8/9 Enter "y" or "n" (or just press <return> for "n") Resolved conflicted state of 'pro/hello.pro'
-#IF SVN1.10 Enter "y" or "n" (or just press <return> for "n") Tree conflict at 'pro/hello.pro' marked as resolved.
+#IF SVN1.10/14 Enter "y" or "n" (or just press <return> for "n") Tree conflict at 'pro/hello.pro' marked as resolved.
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------

--- a/t/fcm-conflicts/02-tree-delete-edit.t
+++ b/t/fcm-conflicts/02-tree-delete-edit.t
@@ -22,6 +22,7 @@
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 check_svn_version
+[[ $SVN_VERSION == "1.13.0" ]] && skip_all "Tests do not work with svn 1.13.0"
 tests 18
 #-------------------------------------------------------------------------------
 setup
@@ -57,7 +58,7 @@ Answer (n) to keep the file.
 Keep the local version?
 Enter "y" or "n" (or just press <return> for "n") A         pro/hello.pro
 #IF SVN1.8/9 Resolved conflicted state of 'pro/hello.pro'
-#IF SVN1.10 Tree conflict at 'pro/hello.pro' marked as resolved.
+#IF SVN1.10/14 Tree conflict at 'pro/hello.pro' marked as resolved.
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
@@ -120,7 +121,7 @@ Answer (y) to accept the local delete.
 Answer (n) to keep the file.
 Keep the local version?
 #IF SVN1.8/9 Enter "y" or "n" (or just press <return> for "n") Resolved conflicted state of 'pro/hello.pro'
-#IF SVN1.10 Enter "y" or "n" (or just press <return> for "n") Tree conflict at 'pro/hello.pro' marked as resolved.
+#IF SVN1.10/14 Enter "y" or "n" (or just press <return> for "n") Tree conflict at 'pro/hello.pro' marked as resolved.
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------

--- a/t/fcm-conflicts/03-tree-delete-rename.t
+++ b/t/fcm-conflicts/03-tree-delete-rename.t
@@ -22,6 +22,7 @@
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 check_svn_version
+[[ $SVN_VERSION == "1.13.0" ]] && skip_all "Tests do not work with svn 1.13.0"
 tests 15
 #-------------------------------------------------------------------------------
 setup
@@ -56,7 +57,7 @@ Answer (y) to accept the local delete.
 Answer (n) to accept the external rename.
 Keep the local version?
 #IF SVN1.8/9 Enter "y" or "n" (or just press <return> for "n") Resolved conflicted state of 'pro/hello.pro'
-#IF SVN1.10 Enter "y" or "n" (or just press <return> for "n") Tree conflict at 'pro/hello.pro' marked as resolved.
+#IF SVN1.10/14 Enter "y" or "n" (or just press <return> for "n") Tree conflict at 'pro/hello.pro' marked as resolved.
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
@@ -100,7 +101,7 @@ Answer (n) to accept the external rename.
 Keep the local version?
 Enter "y" or "n" (or just press <return> for "n") Reverted 'pro/hello.pro.renamed'
 #IF SVN1.8/9 Resolved conflicted state of 'pro/hello.pro'
-#IF SVN1.10 Tree conflict at 'pro/hello.pro' marked as resolved.
+#IF SVN1.10/14 Tree conflict at 'pro/hello.pro' marked as resolved.
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------

--- a/t/fcm-conflicts/04-tree-edit-delete.t
+++ b/t/fcm-conflicts/04-tree-edit-delete.t
@@ -106,7 +106,7 @@ Answer (y) to keep the file.
 Answer (n) to accept the external delete.
 Keep the local version?
 #IF SVN1.8/9 Enter "y" or "n" (or just press <return> for "n") Resolved conflicted state of 'pro/hello.pro'
-#IF SVN1.10 Enter "y" or "n" (or just press <return> for "n") Tree conflict at 'pro/hello.pro' marked as resolved.
+#IF SVN1.10/14 Enter "y" or "n" (or just press <return> for "n") Tree conflict at 'pro/hello.pro' marked as resolved.
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------

--- a/t/fcm-conflicts/06-tree-rename-delete.t
+++ b/t/fcm-conflicts/06-tree-rename-delete.t
@@ -57,7 +57,7 @@ Answer (n) to accept the external delete.
 Keep the local version?
 Enter "y" or "n" (or just press <return> for "n") D         pro/hello.pro.renamed
 #IF SVN1.8/9 Resolved conflicted state of 'pro/hello.pro'
-#IF SVN1.10 Tree conflict at 'pro/hello.pro' marked as resolved.
+#IF SVN1.10/14 Tree conflict at 'pro/hello.pro' marked as resolved.
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
@@ -90,7 +90,7 @@ Answer (y) to accept the local rename.
 Answer (n) to accept the external delete.
 Keep the local version?
 #IF SVN1.8/9 Enter "y" or "n" (or just press <return> for "n") Resolved conflicted state of 'pro/hello.pro'
-#IF SVN1.10 Enter "y" or "n" (or just press <return> for "n") Tree conflict at 'pro/hello.pro' marked as resolved.
+#IF SVN1.10/14 Enter "y" or "n" (or just press <return> for "n") Tree conflict at 'pro/hello.pro' marked as resolved.
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------

--- a/t/fcm-conflicts/07-tree-rename-edit.t
+++ b/t/fcm-conflicts/07-tree-rename-edit.t
@@ -47,50 +47,70 @@ svn commit -q -m "Modified conflict file  (merge)"
 svn update -q
 svn switch -q $ROOT_URL/branches/dev/Share/ctrl
 fcm merge --non-interactive $ROOT_URL/branches/dev/Share/ren_ed >/dev/null
-run_pass "$TEST_KEY" fcm conflicts <<__IN__
+if [[ $SVN_MINOR_VERSION == "1.14" ]]; then
+  run_pass "$TEST_KEY" fcm conflicts <<__IN__
+y
+__IN__
+else
+  run_pass "$TEST_KEY" fcm conflicts <<__IN__
 n
 __IN__
+fi
 file_cmp_filtered "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
-[info] pro/hello.pro: in tree conflict.
-Locally: renamed to pro/hello.pro.renamed.
-Externally: edited.
-Answer (y) to accept the local rename.
-Answer (n) to keep the file.
-You can then merge in changes.
-Keep the local version?
-Enter "y" or "n" (or just press <return> for "n") diff3 pro/hello.pro.renamed.working pro/hello.pro.renamed.merge-left.r1 pro/hello.pro.renamed.merge-right.r8
+#IF SVN1.8/9/10 [info] pro/hello.pro: in tree conflict.
+#IF SVN1.14 [info] pro/hello.pro.renamed: in text conflict.
+#IF SVN1.8/9/10 Locally: renamed to pro/hello.pro.renamed.
+#IF SVN1.8/9/10 Externally: edited.
+#IF SVN1.8/9/10 Answer (y) to accept the local rename.
+#IF SVN1.8/9/10 Answer (n) to keep the file.
+#IF SVN1.8/9/10 You can then merge in changes.
+#IF SVN1.8/9/10 Keep the local version?
+#IF SVN1.8/9/10 Enter "y" or "n" (or just press <return> for "n") diff3 pro/hello.pro.renamed.working pro/hello.pro.renamed.merge-left.r1 pro/hello.pro.renamed.merge-right.r8
+#IF SVN1.14 diff3 $PWD/pro/hello.pro.renamed.3.tmp $PWD/pro/hello.pro.renamed.tmp $PWD/pro/hello.pro.renamed.2.tmp
 ====
 1:3c
   Local contents (1)
 2:2a
 3:3c
   Merge contents (1)
-A         pro/hello.pro
-D         pro/hello.pro.renamed
+#IF SVN1.8/9/10 A         pro/hello.pro
+#IF SVN1.8/9/10 D         pro/hello.pro.renamed
 #IF SVN1.8/9 Resolved conflicted state of 'pro/hello.pro'
 #IF SVN1.10 Tree conflict at 'pro/hello.pro' marked as resolved.
+#IF SVN1.14 Run "svn resolve --accept working pro/hello.pro.renamed"?
+#IF SVN1.14 Enter "y" or "n" (or just press <return> for "n") Merge conflicts in 'pro/hello.pro.renamed' marked as resolved.
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
 # Tests fcm conflicts: rename, edit, discard local (status)
 TEST_KEY=$TEST_KEY_BASE-discard-status
 run_pass "$TEST_KEY" svn status --config-dir=$TEST_DIR/.subversion/
-file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
+file_cmp_filtered "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
  M      .
-A  +    pro/hello.pro
-        > moved from pro/hello.pro.renamed
-D       pro/hello.pro.renamed
-        > moved to pro/hello.pro
+#IF SVN1.8/9/10 A  +    pro/hello.pro
+#IF SVN1.8/9/10         > moved from pro/hello.pro.renamed
+#IF SVN1.8/9/10 D       pro/hello.pro.renamed
+#IF SVN1.8/9/10         > moved to pro/hello.pro
+#IF SVN1.14 M       pro/hello.pro.renamed
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
 # Tests fcm conflicts: rename, edit, discard local (cat)
 TEST_KEY=$TEST_KEY_BASE-discard-cat
-run_pass "$TEST_KEY" cat pro/hello.pro
-file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
+if [[ $SVN_MINOR_VERSION == "1.14" ]]; then
+  run_pass "$TEST_KEY" cat pro/hello.pro.renamed
+else
+  run_pass "$TEST_KEY" cat pro/hello.pro
+fi
+file_cmp_filtered "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
 PRO HELLO
 END
+#IF SVN1.14 <<<<<<< .working
 Local contents (1)
+#IF SVN1.14 ||||||| .old
+#IF SVN1.14 =======
+#IF SVN1.14 Merge contents (1)
+#IF SVN1.14 >>>>>>> .new
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
@@ -107,14 +127,16 @@ run_pass "$TEST_KEY" fcm conflicts <<__IN__
 y
 __IN__
 file_cmp_filtered "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
-[info] pro/hello.pro: in tree conflict.
-Locally: renamed to pro/hello.pro.renamed.
-Externally: edited.
-Answer (y) to accept the local rename.
-Answer (n) to keep the file.
-You can then merge in changes.
-Keep the local version?
-Enter "y" or "n" (or just press <return> for "n") diff3 pro/hello.pro.renamed.working pro/hello.pro.renamed.merge-left.r1 pro/hello.pro.renamed.merge-right.r8
+#IF SVN1.8/9/10 [info] pro/hello.pro: in tree conflict.
+#IF SVN1.14 [info] pro/hello.pro.renamed: in text conflict.
+#IF SVN1.8/9/10 Locally: renamed to pro/hello.pro.renamed.
+#IF SVN1.8/9/10 Externally: edited.
+#IF SVN1.8/9/10 Answer (y) to accept the local rename.
+#IF SVN1.8/9/10 Answer (n) to keep the file.
+#IF SVN1.8/9/10 You can then merge in changes.
+#IF SVN1.8/9/10 Keep the local version?
+#IF SVN1.8/9/10 Enter "y" or "n" (or just press <return> for "n") diff3 pro/hello.pro.renamed.working pro/hello.pro.renamed.merge-left.r1 pro/hello.pro.renamed.merge-right.r8
+#IF SVN1.14 diff3 $PWD/pro/hello.pro.renamed.3.tmp $PWD/pro/hello.pro.renamed.tmp $PWD/pro/hello.pro.renamed.2.tmp
 ====
 1:3c
   Local contents (1)
@@ -123,24 +145,32 @@ Enter "y" or "n" (or just press <return> for "n") diff3 pro/hello.pro.renamed.wo
   Merge contents (1)
 #IF SVN1.8/9 Resolved conflicted state of 'pro/hello.pro'
 #IF SVN1.10 Tree conflict at 'pro/hello.pro' marked as resolved.
+#IF SVN1.14 Run "svn resolve --accept working pro/hello.pro.renamed"?
+#IF SVN1.14 Enter "y" or "n" (or just press <return> for "n") Merge conflicts in 'pro/hello.pro.renamed' marked as resolved.
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
 # Tests fcm conflicts: rename, edit, keep local (status)
 TEST_KEY=$TEST_KEY_BASE-keep-status
 run_pass "$TEST_KEY" svn status --config-dir=$TEST_DIR/.subversion/
-file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
+file_cmp_filtered "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
  M      .
+#IF SVN1.14 M       pro/hello.pro.renamed
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
 # Tests fcm conflicts: rename, edit, keep local (cat)
 TEST_KEY=$TEST_KEY_BASE-keep-cat
 run_pass "$TEST_KEY" cat pro/hello.pro.renamed
-file_cmp "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
+file_cmp_filtered "$TEST_KEY.out" "$TEST_KEY.out" <<__OUT__
 PRO HELLO
 END
+#IF SVN1.14 <<<<<<< .working
 Local contents (1)
+#IF SVN1.14 ||||||| .old
+#IF SVN1.14 =======
+#IF SVN1.14 Merge contents (1)
+#IF SVN1.14 >>>>>>> .new
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 teardown

--- a/t/fcm-conflicts/08-tree-rename-rename-diff.t
+++ b/t/fcm-conflicts/08-tree-rename-rename-diff.t
@@ -22,6 +22,7 @@
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 check_svn_version
+[[ $SVN_VERSION == "1.13.0" ]] && skip_all "Tests do not work with svn 1.13.0"
 tests 18
 #-------------------------------------------------------------------------------
 setup
@@ -70,7 +71,7 @@ Enter "y" or "n" (or just press <return> for "n") diff3 pro/hello.pro.renamed-me
   Merge contents (1)
 D         pro/hello.pro.renamed-local
 #IF SVN1.8/9 Resolved conflicted state of 'pro/hello.pro'
-#IF SVN1.10 Tree conflict at 'pro/hello.pro' marked as resolved.
+#IF SVN1.10/14 Tree conflict at 'pro/hello.pro' marked as resolved.
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
@@ -123,7 +124,7 @@ Enter "y" or "n" (or just press <return> for "n") diff3 pro/hello.pro.renamed-lo
   Merge contents (1)
 Reverted 'pro/hello.pro.renamed-merge'
 #IF SVN1.8/9 Resolved conflicted state of 'pro/hello.pro'
-#IF SVN1.10 Tree conflict at 'pro/hello.pro' marked as resolved.
+#IF SVN1.10/14 Tree conflict at 'pro/hello.pro' marked as resolved.
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------

--- a/t/fcm-conflicts/09-tree-rename-rename-same.t
+++ b/t/fcm-conflicts/09-tree-rename-rename-same.t
@@ -23,6 +23,7 @@
 . $(dirname $0)/test_header
 #-------------------------------------------------------------------------------
 check_svn_version
+[[ $SVN_VERSION == "1.13.0" ]] && skip_all "Tests do not work with svn 1.13.0"
 tests 27
 #-------------------------------------------------------------------------------
 setup
@@ -63,7 +64,7 @@ Answer (n) to accept the external delete.
 Keep the local version?
 Enter "y" or "n" (or just press <return> for "n") D         pro/hello.pro.renamed
 #IF SVN1.8/9 Resolved conflicted state of 'pro/hello.pro'
-#IF SVN1.10 Tree conflict at 'pro/hello.pro' marked as resolved.
+#IF SVN1.10/14 Tree conflict at 'pro/hello.pro' marked as resolved.
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
@@ -105,7 +106,7 @@ Answer (y) to accept the local rename.
 Answer (n) to accept the external delete.
 Keep the local version?
 #IF SVN1.8/9 Enter "y" or "n" (or just press <return> for "n") Resolved conflicted state of 'pro/hello.pro'
-#IF SVN1.10 Enter "y" or "n" (or just press <return> for "n") Tree conflict at 'pro/hello.pro' marked as resolved.
+#IF SVN1.10/14 Enter "y" or "n" (or just press <return> for "n") Tree conflict at 'pro/hello.pro' marked as resolved.
 [info] pro/hello.pro.renamed: in tree conflict.
 Locally: added.
 Externally: added.
@@ -113,7 +114,7 @@ Answer (y) to keep the local file filename.
 Answer (n) to keep the external file filename.
 Keep the local version?
 #IF SVN1.8/9 Enter "y" or "n" (or just press <return> for "n") Resolved conflicted state of 'pro/hello.pro.renamed'
-#IF SVN1.10 Enter "y" or "n" (or just press <return> for "n") Tree conflict at 'pro/hello.pro.renamed' marked as resolved.
+#IF SVN1.10/14 Enter "y" or "n" (or just press <return> for "n") Tree conflict at 'pro/hello.pro.renamed' marked as resolved.
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
@@ -157,7 +158,7 @@ Answer (y) to accept the local rename.
 Answer (n) to accept the external delete.
 Keep the local version?
 #IF SVN1.8/9 Enter "y" or "n" (or just press <return> for "n") Resolved conflicted state of 'pro/hello.pro'
-#IF SVN1.10 Enter "y" or "n" (or just press <return> for "n") Tree conflict at 'pro/hello.pro' marked as resolved.
+#IF SVN1.10/14 Enter "y" or "n" (or just press <return> for "n") Tree conflict at 'pro/hello.pro' marked as resolved.
 [info] pro/hello.pro.renamed: in tree conflict.
 Locally: added.
 Externally: added.
@@ -165,7 +166,7 @@ Answer (y) to keep the local file filename.
 Answer (n) to keep the external file filename.
 Keep the local version?
 #IF SVN1.8/9 Enter "y" or "n" (or just press <return> for "n") Resolved conflicted state of 'pro/hello.pro.renamed'
-#IF SVN1.10 Enter "y" or "n" (or just press <return> for "n") Tree conflict at 'pro/hello.pro.renamed' marked as resolved.
+#IF SVN1.10/14 Enter "y" or "n" (or just press <return> for "n") Tree conflict at 'pro/hello.pro.renamed' marked as resolved.
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------

--- a/t/fcm-conflicts/10-text.t
+++ b/t/fcm-conflicts/10-text.t
@@ -123,7 +123,7 @@ diff3 $PWD/lib/python/info/poems.py.working $PWD/lib/python/info/poems.py.merge-
   prINt "\n",  __doc__
 Run "svn resolve --accept working lib/python/info/poems.py"?
 #IF SVN1.8/9 Enter "y" or "n" (or just press <return> for "n") Resolved conflicted state of 'lib/python/info/poems.py'
-#IF SVN1.10 Enter "y" or "n" (or just press <return> for "n") Merge conflicts in 'lib/python/info/poems.py' marked as resolved.
+#IF SVN1.10/14 Enter "y" or "n" (or just press <return> for "n") Merge conflicts in 'lib/python/info/poems.py' marked as resolved.
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------

--- a/t/fcm-conflicts/11-tree-edit-replace.t
+++ b/t/fcm-conflicts/11-tree-edit-replace.t
@@ -54,7 +54,7 @@ Answer (y) to keep the file.
 Answer (n) to accept the external replace.
 Keep the local version?
 #IF SVN1.8/9 Enter "y" or "n" (or just press <return> for "n") Resolved conflicted state of 'pro/hello.pro'
-#IF SVN1.10 Enter "y" or "n" (or just press <return> for "n") Tree conflict at 'pro/hello.pro' marked as resolved.
+#IF SVN1.10/14 Enter "y" or "n" (or just press <return> for "n") Tree conflict at 'pro/hello.pro' marked as resolved.
 __OUT__
 file_cmp "${TEST_KEY}.err" "${TEST_KEY}.err" <'/dev/null'
 #-------------------------------------------------------------------------------

--- a/t/fcm-merge/00-simple.t
+++ b/t/fcm-merge/00-simple.t
@@ -160,16 +160,16 @@ Index: .
 Property changes on: .
 ___________________________________________________________________
 Added: svn:mergeinfo
-#IF SVN1.9/10 ## -0,0 +0,1 ##
+#IF SVN1.9/10/14 ## -0,0 +0,1 ##
    Merged /branches/dev/Share/merge1:r4-5
-#IF SVN1.9/10 Index: added_directory/hello_constants.f90
-#IF SVN1.9/10 ===================================================================
-#IF SVN1.9/10 Index: added_directory/hello_constants.inc
-#IF SVN1.9/10 ===================================================================
-#IF SVN1.9/10 Index: added_directory/hello_constants_dummy.inc
-#IF SVN1.9/10 ===================================================================
-#IF SVN1.9/10 Index: added_file
-#IF SVN1.9/10 ===================================================================
+#IF SVN1.9/10/14 Index: added_directory/hello_constants.f90
+#IF SVN1.9/10/14 ===================================================================
+#IF SVN1.9/10/14 Index: added_directory/hello_constants.inc
+#IF SVN1.9/10/14 ===================================================================
+#IF SVN1.9/10/14 Index: added_directory/hello_constants_dummy.inc
+#IF SVN1.9/10/14 ===================================================================
+#IF SVN1.9/10/14 Index: added_file
+#IF SVN1.9/10/14 ===================================================================
 Index: lib/python/info/poems.py
 ===================================================================
 --- lib/python/info/poems.py	(revision 9)
@@ -234,8 +234,8 @@ Index: module/hello_constants_dummy.inc
 @@ -1 +1 @@
 -INCLUDE 'hello_constants.inc'
 +INCLUDE 'hello_constants.INc'
-#IF SVN1.9/10 Index: module/tree_conflict_file
-#IF SVN1.9/10 ===================================================================
+#IF SVN1.9/10/14 Index: module/tree_conflict_file
+#IF SVN1.9/10/14 ===================================================================
 Index: subroutine/hello_sub_dummy.h
 ===================================================================
 --- subroutine/hello_sub_dummy.h	(revision 9)

--- a/t/fcm-merge/01-complex.t
+++ b/t/fcm-merge/01-complex.t
@@ -105,7 +105,7 @@ Index: .
 Property changes on: .
 ___________________________________________________________________
 Added: svn:mergeinfo
-#IF SVN1.9/10 ## -0,0 +0,1 ##
+#IF SVN1.9/10/14 ## -0,0 +0,1 ##
    Merged /${PROJECT}trunk:r2-9
 Index: lib/python/info/__init__.py
 ===================================================================
@@ -306,16 +306,16 @@ Index: .
 Property changes on: .
 ___________________________________________________________________
 Added: svn:mergeinfo
-#IF SVN1.9/10 ## -0,0 +0,1 ##
+#IF SVN1.9/10/14 ## -0,0 +0,1 ##
    Merged /${PROJECT}branches/dev/Share/merge1:r4-11
-#IF SVN1.9/10 Index: added_directory/hello_constants.f90
-#IF SVN1.9/10 ===================================================================
-#IF SVN1.9/10 Index: added_directory/hello_constants.inc
-#IF SVN1.9/10 ===================================================================
-#IF SVN1.9/10 Index: added_directory/hello_constants_dummy.inc
-#IF SVN1.9/10 ===================================================================
-#IF SVN1.9/10 Index: added_file
-#IF SVN1.9/10 ===================================================================
+#IF SVN1.9/10/14 Index: added_directory/hello_constants.f90
+#IF SVN1.9/10/14 ===================================================================
+#IF SVN1.9/10/14 Index: added_directory/hello_constants.inc
+#IF SVN1.9/10/14 ===================================================================
+#IF SVN1.9/10/14 Index: added_directory/hello_constants_dummy.inc
+#IF SVN1.9/10/14 ===================================================================
+#IF SVN1.9/10/14 Index: added_file
+#IF SVN1.9/10/14 ===================================================================
 Index: lib/python/info/poems.py
 ===================================================================
 --- lib/python/info/poems.py	(revision 11)
@@ -380,8 +380,8 @@ Index: module/hello_constants_dummy.inc
 @@ -1 +1 @@
 -INCLUDE 'hello_constants.inc'
 +INCLUDE 'hello_constants.INc'
-#IF SVN1.9/10 Index: module/tree_conflict_file
-#IF SVN1.9/10 ===================================================================
+#IF SVN1.9/10/14 Index: module/tree_conflict_file
+#IF SVN1.9/10/14 ===================================================================
 Index: subroutine/hello_sub_dummy.h
 ===================================================================
 --- subroutine/hello_sub_dummy.h	(revision 11)
@@ -580,7 +580,7 @@ Index: .
 Property changes on: .
 ___________________________________________________________________
 Modified: svn:mergeinfo
-#IF SVN1.9/10 ## -0,0 +0,1 ##
+#IF SVN1.9/10/14 ## -0,0 +0,1 ##
    Merged /${PROJECT}branches/dev/Share/merge1:r12-13
 Index: added_file
 ===================================================================
@@ -772,7 +772,7 @@ Index: .
 Property changes on: .
 ___________________________________________________________________
 Modified: svn:mergeinfo
-#IF SVN1.9/10 ## -0,0 +0,1 ##
+#IF SVN1.9/10/14 ## -0,0 +0,1 ##
    Merged /${PROJECT}trunk:r10-16
 Index: added_file
 ===================================================================
@@ -979,7 +979,7 @@ Index: .
 Property changes on: .
 ___________________________________________________________________
 Modified: svn:mergeinfo
-#IF SVN1.9/10 ## -0,0 +0,1 ##
+#IF SVN1.9/10/14 ## -0,0 +0,1 ##
    Merged /${PROJECT}branches/dev/Share/merge1:r14-19
 Index: added_directory/hello_constants_dummy.inc
 ===================================================================
@@ -988,8 +988,8 @@ Index: added_directory/hello_constants_dummy.inc
 @@ -1,2 +0,0 @@
 -INCLUDE 'hello_constants.INc'
 -# added this line for simple repeat testing
-#IF SVN1.9/10 Index: added_file.add
-#IF SVN1.9/10 ===================================================================
+#IF SVN1.9/10/14 Index: added_file.add
+#IF SVN1.9/10/14 ===================================================================
 __OUT__
 file_cmp "$TEST_KEY.err" "$TEST_KEY.err" </dev/null
 #-------------------------------------------------------------------------------
@@ -1289,17 +1289,17 @@ Index: .
 Property changes on: .
 ___________________________________________________________________
 Added: svn:mergeinfo
-#IF SVN1.9/10 ## -0,0 +0,2 ##
+#IF SVN1.9/10/14 ## -0,0 +0,2 ##
    Merged /${PROJECT}trunk:r2-9
    Merged /${PROJECT}branches/dev/Share/merge1:r4-13
-#IF SVN1.9/10 Index: added_directory/hello_constants.f90
-#IF SVN1.9/10 ===================================================================
-#IF SVN1.9/10 Index: added_directory/hello_constants.inc
-#IF SVN1.9/10 ===================================================================
-#IF SVN1.9/10 Index: added_directory/hello_constants_dummy.inc
-#IF SVN1.9/10 ===================================================================
-#IF SVN1.9/10 Index: added_file
-#IF SVN1.9/10 ===================================================================
+#IF SVN1.9/10/14 Index: added_directory/hello_constants.f90
+#IF SVN1.9/10/14 ===================================================================
+#IF SVN1.9/10/14 Index: added_directory/hello_constants.inc
+#IF SVN1.9/10/14 ===================================================================
+#IF SVN1.9/10/14 Index: added_directory/hello_constants_dummy.inc
+#IF SVN1.9/10/14 ===================================================================
+#IF SVN1.9/10/14 Index: added_file
+#IF SVN1.9/10/14 ===================================================================
 Index: lib/python/info/__init__.py
 ===================================================================
 --- lib/python/info/__init__.py	(revision 21)
@@ -1372,8 +1372,8 @@ Index: module/hello_constants_dummy.inc
 @@ -1 +1 @@
 -INCLUDE 'hello_constants.inc'
 +INCLUDE 'hello_constants.INc'
-#IF SVN1.9/10 Index: module/tree_conflict_file
-#IF SVN1.9/10 ===================================================================
+#IF SVN1.9/10/14 Index: module/tree_conflict_file
+#IF SVN1.9/10/14 ===================================================================
 Index: subroutine/hello_sub_dummy.h
 ===================================================================
 --- subroutine/hello_sub_dummy.h	(revision 21)

--- a/t/lib/bash/test_header
+++ b/t/lib/bash/test_header
@@ -99,6 +99,7 @@ function FINALLY() {
     done
     if [[ -n $TEST_DIR ]]; then
         cd ~
+        # DPM
         rm -rf $TEST_DIR
     fi
     if declare -F FINALLY_MORE >/dev/null; then
@@ -175,25 +176,41 @@ function file_cmp_filtered() {
         cat $FILE_EXPECT | sed \
           -e "s/^#IF SVN1.8 //g" \
           -e "s/^#IF SVN1.8\/9 //g" \
-          -e "/^#IF SVN1.9 /d" \
+          -e "s/^#IF SVN1.8\/9\/10 //g" \
+          -e "/^#IF SVN1.9\/10\/14 /d" \
           -e "/^#IF SVN1.10 /d" \
-          -e "/^#IF SVN1.9\/10 /d" \
+          -e "/^#IF SVN1.10\/14 /d" \
+          -e "/^#IF SVN1.14 /d" \
           >"$TEST_DIR/$TEST_KEY.filtered-ctrl"
     elif [[ $SVN_MINOR_VERSION == "1.9" ]]; then
         cat $FILE_EXPECT | sed \
-          -e "s/^#IF SVN1.9 //g" \
           -e "s/^#IF SVN1.8\/9 //g" \
-          -e "s/^#IF SVN1.9\/10 //g" \
+          -e "s/^#IF SVN1.8\/9\/10 //g" \
+          -e "s/^#IF SVN1.9\/10\/14 //g" \
           -e "/^#IF SVN1.8 /d" \
           -e "/^#IF SVN1.10 /d" \
+          -e "/^#IF SVN1.10\/14 /d" \
+          -e "/^#IF SVN1.14 /d" \
+          >"$TEST_DIR/$TEST_KEY.filtered-ctrl"
+    elif [[ $SVN_MINOR_VERSION == "1.10" ]]; then
+        cat $FILE_EXPECT | sed \
+          -e "s/^#IF SVN1.8\/9\/10 //g" \
+          -e "s/^#IF SVN1.9\/10\/14 //g" \
+          -e "s/^#IF SVN1.10 //g" \
+          -e "s/^#IF SVN1.10\/14 //g" \
+          -e "/^#IF SVN1.8 /d" \
+          -e "/^#IF SVN1.8\/9 /d" \
+          -e "/^#IF SVN1.14 /d" \
           >"$TEST_DIR/$TEST_KEY.filtered-ctrl"
     else
         cat $FILE_EXPECT | sed \
-          -e "s/^#IF SVN1.10 //g" \
-          -e "s/^#IF SVN1.9\/10 //g" \
+          -e "s/^#IF SVN1.10\/14 //g" \
+          -e "s/^#IF SVN1.9\/10\/14 //g" \
           -e "/^#IF SVN1.8 /d" \
-          -e "/^#IF SVN1.9 /d" \
           -e "/^#IF SVN1.8\/9 /d" \
+          -e "/^#IF SVN1.8\/9\/10 /d" \
+          -e "/^#IF SVN1.10 /d" \
+          -e "s/^#IF SVN1.14 //g" \
           >"$TEST_DIR/$TEST_KEY.filtered-ctrl"
     fi
     file_cmp "$1" "$2" "$TEST_DIR/$TEST_KEY.filtered-ctrl"
@@ -234,13 +251,13 @@ function commit_sort() {
     # Sort the svn status part of the message
     status_sort $INPUT_FILE $TMP_OUTPUT_FILE
     # Sort the 'Adding/Deleting', etc part of the message
-    python2 -c 'import re, sys
+    python3 -c 'import re, sys
 text = sys.stdin.read()
-sending_lines = re.findall("^\w+ing  +.*$", text, re.M)
+sending_lines = re.findall(r"^\w+ing  +.*$", text, re.M)
 prefix = text[:text.index(sending_lines[0])]
 suffix = text[(text.index(sending_lines[-1]) + len(sending_lines[-1])):]
 sending_lines.sort()
-print prefix + "\n".join(sending_lines) + suffix.rstrip()
+print(prefix + "\n".join(sending_lines) + suffix.rstrip())
 ' <"$TMP_OUTPUT_FILE" >"$OUTPUT_FILE"
     rm "$TMP_OUTPUT_FILE"
     # Remove 1.8 to 1.9 specific changes (transmitting, transaction lines).
@@ -252,10 +269,10 @@ function diff_sort() {
     local INPUT_FILE=$1
     local OUTPUT_FILE=$2
     # Sort the diff file order.
-    python2 -c 'import re, sys
+    python3 -c 'import re, sys
 text = sys.stdin.read()
-print "\nIndex: ".join(
-    [l.strip() for l in sorted(re.compile("^Index: ", re.M).split(text))])
+print("\nIndex: ".join(
+    [l.strip() for l in sorted(re.compile(r"^Index: ", re.M).split(text))]))
 ' <"$INPUT_FILE" >"$OUTPUT_FILE"
     # In 1.9, new files are (nonexistent) rather than (working copy).
     sed -i "s/(nonexistent)/(working copy)/" "$OUTPUT_FILE"
@@ -264,46 +281,46 @@ print "\nIndex: ".join(
 function status_sort() {
     local INPUT_FILE=$1
     local OUTPUT_FILE=$2
-    python2 -c 'import re, sys
+    python3 -c 'import re, sys
 text = sys.stdin.read()
-status_lines = re.findall("^.{7} [\w./].*$", text, re.M)
+status_lines = re.findall(r"^.{7} [\w./].*$", text, re.M)
 prefix = text[:text.index(status_lines[0])]
 suffix = text[(text.index(status_lines[-1]) + len(status_lines[-1])):]
 status_lines.sort()
-print prefix + "\n".join(status_lines) + suffix.rstrip()
+print(prefix + "\n".join(status_lines) + suffix.rstrip())
 ' <"$INPUT_FILE" >"$OUTPUT_FILE"
 }
 
 function merge_sort() {
     local INPUT_FILE=$1
     local OUTPUT_FILE=$2
-    python2 -c 'import re, sys
+    python3 -c 'import re, sys
 text = sys.stdin.read()
 status_lines = []
 for line in text.splitlines():
     if line.startswith("Enter \"y\"") and ": " in line:
         head, tail = line.split(": ", 1)
         if status_lines:
-            print "\n".join(sorted(status_lines))
+            print("\n".join(sorted(status_lines)))
             status_lines = []
-        print head + ": "
+        print(head + ": ")
         if tail:
             line = tail
-    if re.search("^.{4} [\w./].*$", line):
+    if re.search(r"^.{4} [\w./].*$", line):
         status_lines.append(line)
     elif status_lines:
-        print "\n".join(sorted(status_lines))
-        print line
+        print("\n".join(sorted(status_lines)))
+        print(line)
         status_lines = []
     else:
-        print line
+        print(line)
 if status_lines:
-    print "\n".join(sorted(status_lines))
+    print("\n".join(sorted(status_lines)))
 ' <"$INPUT_FILE" >"$OUTPUT_FILE"
 }
 
 function check_svn_version() {
-    if [[ ! $SVN_MINOR_VERSION =~ ^1\.(8|9|10)$ ]]; then
+    if [[ ! $SVN_MINOR_VERSION =~ ^1\.(8|9|10|14)$ ]]; then
         skip_all "Tests require Subversion 1.8 or later"
         exit 0
     fi
@@ -333,11 +350,14 @@ export FCM_HOME
 PATH=$FCM_HOME/bin:$PATH
 
 SVN_MINOR_VERSION=undef
+SVN_VERSION=undef
 if svn --version 1>/dev/null 2>&1; then
     SVN_MINOR_VERSION=$(svn --version | \
                         sed -n "s/^svn, version 1.\([0-9]\+\)\.[0-9]\+ .*/1.\1/p")
-    # Treat versions 1.10 and above the same for the moment
-    [[ $SVN_MINOR_VERSION =~ ^1\.1[0-9]$ ]] && SVN_MINOR_VERSION=1.10
+    SVN_VERSION=$(svn --version | \
+                        sed -n "s/^svn, version 1.\([0-9\.]\+\) .*/1.\1/p")
+    # Treat version 1.13 like 1.14
+    [[ $SVN_MINOR_VERSION == "1.13" ]] && SVN_MINOR_VERSION=1.14
 fi
 
 TEST_KEY_BASE=$(basename $0 .t)


### PR DESCRIPTION
Also

- Replace Ubuntu 18.04 with 22.04 in github actions
- Skip tests which are broken with svn 1.13.0 (Ubuntu 20.04)
- Use Python 3 (not 2) in tests